### PR TITLE
Ensure matplotlib backend is configured before importing pyplot

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -12,6 +12,9 @@ from typing import Dict
 import cv2
 import imutils
 import matplotlib as mpl
+
+mpl.use("Agg")
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns
@@ -30,11 +33,6 @@ from deepface import DeepFace
 
 from .forms import DateForm, DateForm_2, UsernameAndDateForm, usernameForm
 from users.models import Present, Time
-
-
-mpl.use("Agg")
-
-
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
- move the mpl.use("Agg") call in recognition/views.py so the backend is selected immediately after importing matplotlib

## Testing
- python - <<'PY'
import os
os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'attendance_system_facial_recognition.settings')
import django
django.setup()
from recognition import views
import matplotlib.pyplot as plt
fig = plt.figure()
ax = fig.add_subplot(111)
ax.plot([0, 1], [0, 1])
fig.savefig('/tmp/test_plot.png')
print('saved')
PY

------
https://chatgpt.com/codex/tasks/task_b_68de34c94bcc8323a5e2c2e0801ef615