### PR TITLE
Use staff flags instead of admin username checks

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -362,7 +362,7 @@ def home(request):
 
 @login_required
 def dashboard(request):
-    if request.user.username == "admin":
+    if request.user.is_staff or request.user.is_superuser:
         logger.debug("Rendering admin dashboard for %s", request.user)
         return render(request, "recognition/admin_dashboard.html")
     else:
@@ -373,7 +373,7 @@ def dashboard(request):
 
 @login_required
 def add_photos(request):
-    if request.user.username != "admin":
+    if not (request.user.is_staff or request.user.is_superuser):
         return redirect("not-authorised")
     if request.method == "POST":
         form = usernameForm(request.POST)
@@ -480,7 +480,7 @@ def train(request):
     This view is now obsolete as DeepFace does not require a separate training step.
     The 'training' is implicitly handled by organizing images in folders.
     """
-    if request.user.username != "admin":
+    if not (request.user.is_staff or request.user.is_superuser):
         return redirect("not-authorised")
 
     messages.info(
@@ -510,7 +510,7 @@ def view_attendance_home(request):
 
 @login_required
 def view_attendance_date(request):
-    if request.user.username != "admin":
+    if not (request.user.is_staff or request.user.is_superuser):
         return redirect("not-authorised")
     qs = None
     time_qs = None
@@ -541,7 +541,7 @@ def view_attendance_date(request):
 
 @login_required
 def view_attendance_employee(request):
-    if request.user.username != "admin":
+    if not (request.user.is_staff or request.user.is_superuser):
         return redirect("not-authorised")
     time_qs = None
     present_qs = None
@@ -585,7 +585,7 @@ def view_attendance_employee(request):
 
 
 def view_my_attendance_employee_login(request):
-    if request.user.username == "admin":
+    if request.user.is_staff or request.user.is_superuser:
         return redirect("not-authorised")
     qs = None
     time_qs = None


### PR DESCRIPTION
## Summary
- replace username-based admin checks in recognition views with staff or superuser role checks
- add regression tests covering staff users with non-"admin" usernames and ensure employees remain restricted
- stub the cv2 dependency in tests to avoid system-level library requirements during the suite

## Testing
- python manage.py test recognition

------
https://chatgpt.com/codex/tasks/task_b_68de34d6d8148323a4e079ebda7d9bff