### PR TITLE
Handle missing users when updating attendance

### DIFF
--- a/recognition/tests.py
+++ b/recognition/tests.py
@@ -109,6 +109,18 @@ class DatabaseUpdateTest(TestCase):
             Time.objects.filter(user=self.user, date=self.today, out=True).exists()
         )
 
+    def test_update_attendance_handles_missing_user(self):
+        missing_username = "ghost"
+        self.assertFalse(User.objects.filter(username=missing_username).exists())
+
+        try:
+            views.update_attendance_in_db_in({missing_username: True})
+        except Exception as exc:  # pragma: no cover - fail loudly if raised
+            self.fail(f"update_attendance_in_db_in raised an exception: {exc}")
+
+        self.assertFalse(Present.objects.filter(date=self.today).exists())
+        self.assertFalse(Time.objects.filter(date=self.today).exists())
+
 
 class AddPhotosTest(TestCase):
     def setUp(self):

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -96,7 +96,14 @@ def update_attendance_in_db_in(present: Dict[str, bool]) -> None:
     today = timezone.localdate()
     current_time = timezone.now()
     for person, is_present in present.items():
-        user = User.objects.get(username=person)
+        user = User.objects.filter(username=person).first()
+        if user is None:
+            logger.warning(
+                "Skipping check-in attendance update for unknown user '%s'. "
+                "Training data may be stale.",
+                person,
+            )
+            continue
         qs = Present.objects.filter(user=user, date=today).first()
 
         if qs is None:
@@ -119,7 +126,14 @@ def update_attendance_in_db_out(present: Dict[str, bool]) -> None:
         if not is_present:
             continue
 
-        user = User.objects.get(username=person)
+        user = User.objects.filter(username=person).first()
+        if user is None:
+            logger.warning(
+                "Skipping check-out attendance update for unknown user '%s'. "
+                "Training data may be stale.",
+                person,
+            )
+            continue
         Time.objects.create(user=user, date=today, time=current_time, out=True)
 
 


### PR DESCRIPTION
## Summary
- guard the attendance update helpers against missing users and emit warnings for stale training data
- extend the database update test coverage to ensure missing users are ignored without raising

## Testing
- `python manage.py test recognition` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_b_68de34da677083239b3b5d99c73f14e4