### PR TITLE
Exclude admin accounts from employee totals

### DIFF
--- a/recognition/tests.py
+++ b/recognition/tests.py
@@ -199,6 +199,19 @@ class AdminAccessViewsTest(TestCase):
             response, "recognition/view_attendance_date.html"
         )
 
+    def test_view_attendance_home_employee_count_excludes_admin_accounts(self):
+        self.client.force_login(self.staff_user)
+
+        User.objects.create_superuser(
+            "admin", "admin@example.com", "password"
+        )
+        User.objects.create_user("employee2", "employee2@example.com", "password")
+
+        response = self.client.get(reverse("view-attendance-home"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["total_num_of_emp"], 2)
+
         response = self.client.get(reverse("view-attendance-employee"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -268,8 +268,9 @@ def hours_vs_employee_given_date(present_qs, time_qs):
 
 
 def total_number_employees() -> int:
-    qs = User.objects.all()
-    return len(qs) - 1
+    """Return the total count of non-staff, non-superuser employees."""
+
+    return User.objects.filter(is_staff=False, is_superuser=False).count()
 
 
 def employees_present_today() -> int:


### PR DESCRIPTION
## Summary
- filter the employee total to ignore staff and superuser accounts using an efficient queryset count
- add a regression test ensuring the attendance dashboard reports the updated total

## Testing
- python manage.py test recognition

------
https://chatgpt.com/codex/tasks/task_b_68df9c2ab8088331bfbe7d62079ca4ac