### PR TITLE
Require authentication for attendance marking views

### DIFF
--- a/recognition/tests.py
+++ b/recognition/tests.py
@@ -43,6 +43,7 @@ class DeepFaceAttendanceTest(TestCase):
         self, mock_videostream, mock_cv2, mock_deepface_find, mock_update_db
     ):
         request = self.factory.get("/mark_attendance/")
+        request.user = self.user
         self._setup_mocks(mock_videostream, mock_cv2)
 
         # Simulate DeepFace finding a user
@@ -71,6 +72,7 @@ class DeepFaceAttendanceTest(TestCase):
         self, mock_videostream, mock_cv2, mock_deepface_find, mock_update_db
     ):
         request = self.factory.get("/mark_attendance_out/")
+        request.user = self.user
         self._setup_mocks(mock_videostream, mock_cv2)
 
         # Simulate DeepFace finding a user

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -478,10 +478,12 @@ def _mark_attendance(request, check_in):
     return redirect("home")
 
 
+@login_required
 def mark_your_attendance(request):
     return _mark_attendance(request, check_in=True)
 
 
+@login_required
 def mark_your_attendance_out(request):
     return _mark_attendance(request, check_in=False)
 


### PR DESCRIPTION
## Summary
- protect the mark_your_attendance and mark_your_attendance_out views with login checks
- update unit tests to authenticate requests before invoking the views
- verify that the Django test suite passes with the new requirements

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_b_68df9c2cb94c8331820bd300a0e17d83