### PR TITLE
Handle missing timestamps in Time model string representation

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -58,4 +58,9 @@ class Time(models.Model):
     def __str__(self):
         """Return a string representation of the time entry."""
         event_type = "Time-Out" if self.out else "Time-In"
-        return f"{self.user.username} - {self.time.strftime('%Y-%m-%d %H:%M:%S')} - {event_type}"
+        if self.time is not None:
+            formatted_time = self.time.strftime("%Y-%m-%d %H:%M:%S")
+        else:
+            formatted_time = "No timestamp recorded"
+
+        return f"{self.user.username} - {formatted_time} - {event_type}"

--- a/users/tests.py
+++ b/users/tests.py
@@ -9,6 +9,8 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.test import TestCase
 
+from .models import Time
+
 
 class RegisterViewTests(TestCase):
     """Test suite for the user registration view."""
@@ -85,4 +87,21 @@ class RegisterViewTests(TestCase):
         self.assertRedirects(response, self.not_authorised_url)
         self.assertFalse(
             get_user_model().objects.filter(username="should_not_create").exists()
+        )
+
+
+class TimeModelTests(TestCase):
+    """Test suite for the Time model."""
+
+    def test_time_str_handles_missing_timestamp(self):
+        """The string representation should handle a missing timestamp gracefully."""
+
+        user = get_user_model().objects.create_user(
+            username="time_user", password="Testpass123"
+        )
+        time_entry = Time(user=user, time=None, out=False)
+
+        self.assertEqual(
+            str(time_entry),
+            "time_user - No timestamp recorded - Time-In",
         )


### PR DESCRIPTION
## Summary
- guard the Time model string representation against missing timestamps by falling back to readable text
- add a regression test ensuring Time.__str__ handles None timestamps without raising

## Testing
- python manage.py test users *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6901a9dae0c08330b221015940b3f9b7