### PR TITLE
Harden Django configuration defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Run Tests
+      env:
+        DJANGO_DEBUG: "True"
+        DJANGO_ALLOWED_HOSTS: "localhost,127.0.0.1"
+        DJANGO_SECRET_KEY: "test-secret-key"
       run: |
         python manage.py test

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ Follow these instructions to get a copy of the project up and running on your lo
 
 ### Configuration
 
+Before running the project you should configure the following environment variables:
+
+- `DJANGO_DEBUG` (default: `False`): enables Django's debug mode for local development.
+  Set it to `True` when you want verbose error pages and auto-reload behaviour.
+- `DJANGO_ALLOWED_HOSTS`: a comma-separated list of hostnames that Django is allowed to
+  serve. This value is required when `DJANGO_DEBUG` is `False`.
+- `DJANGO_SECRET_KEY`: a cryptographically secure secret key. This must be set in
+  production deployments. The built-in development key is only accepted when
+  `DJANGO_DEBUG` is explicitly enabled.
 - `RECOGNITION_DISTANCE_THRESHOLD` (default: `0.4`): sets the maximum
   allowable embedding distance returned by DeepFace when marking attendance.
   Lower values make recognition stricter, while higher values are more


### PR DESCRIPTION
## Summary
- default Django DEBUG to false and enforce explicit secret key and allowed hosts in production
- document the required DJANGO_* environment variables for configuring deployments
- update the CI workflow to provide the new settings when running tests

## Testing
- `python manage.py check` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6901a9e23bf08330a5ede4b07aca8d46