### PR TITLE
Handle small dataset splits and optional subgroup reports

### DIFF
--- a/recognition/analysis/failures.py
+++ b/recognition/analysis/failures.py
@@ -271,7 +271,7 @@ def analyze_subgroups(
     y_pred: np.ndarray,
     y_scores: np.ndarray,
     groups: np.ndarray,
-    output_path: Path,
+    output_path: Optional[Path],
 ) -> pd.DataFrame:
     """
     Perform subgroup analysis to detect bias.
@@ -314,7 +314,8 @@ def analyze_subgroups(
         rows.append(row)
 
     df = pd.DataFrame(rows)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(output_path, index=False)
+    if output_path is not None:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(output_path, index=False)
 
     return df

--- a/recognition/data_splits.py
+++ b/recognition/data_splits.py
@@ -71,12 +71,28 @@ def create_stratified_splits(
     )
 
     # Second split: val vs test
-    val_persons, test_persons = train_test_split(
-        temp_persons,
-        test_size=(test_ratio / (val_ratio + test_ratio)),
-        random_state=random_state,
-        shuffle=True,
-    )
+    val_persons: List[str] = []
+    test_persons: List[str] = []
+
+    if len(temp_persons) >= 2:
+        val_persons, test_persons = train_test_split(
+            temp_persons,
+            test_size=(test_ratio / (val_ratio + test_ratio)),
+            random_state=random_state,
+            shuffle=True,
+        )
+    elif len(temp_persons) == 1:
+        # When only a single person remains after the initial split, assign them
+        # to the validation or test split based on the larger ratio to avoid
+        # train_test_split raising an error for insufficient samples.
+        single_person = temp_persons[0]
+        if val_ratio >= test_ratio:
+            val_persons = [single_person]
+            test_persons = []
+        else:
+            val_persons = []
+            test_persons = [single_person]
+    # If no persons remain in temp_persons the default empty lists above are used.
 
     # Collect all images for each split
     train_paths = []


### PR DESCRIPTION
## Summary
- prevent stratified splitting from failing when only one person remains for validation/test selection
- make subgroup analysis reporting optional when no output path is supplied to avoid attribute errors

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_690a3fdb90108330869fe37dc2aa5a23