### PR TITLE
Clarify training workflow

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -100,6 +100,8 @@ The project includes a comprehensive `Makefile` for common development tasks:
 - `make ablation`: Run ablation experiments
 - `make report`: Generate comprehensive reports (evaluation + ablation)
 
+> **Note:** Model training is triggered automatically whenever new employee photos are captured. The legacy `make train` target now just prints a reminder and points to `make evaluate`/`make report` for checking metrics.
+
 ### Reproducibility
 - `make reproduce`: Complete reproducibility workflow (setup → splits → evaluation → reports)
 

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,10 @@ run:
 	@echo "Starting the development server at http://127.0.0.1:8000/"
 	python manage.py runserver
 
-# Train the face recognition model
+# Train target retained for compatibility but training happens automatically
 train:
-	@echo "Training face recognition model..."
-	python manage.py train_model
-	@echo "Training complete."
+	@echo "Training is automatic when new photos are added; no manual step is required."
+	@echo "If you want to assess model quality, run 'make evaluate' or 'make report'."
 
 # Run evaluation and generate metrics
 evaluate:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is a fully refactored and modernized smart attendance system that l
 - **Responsive Web Interface:** A clean, modern, and intuitive UI that works beautifully on desktops, tablets, and mobile devices.
 - **Admin Dashboard:** A powerful dashboard for administrators to manage employees, add user photos, and view comprehensive attendance reports.
 - **Employee Dashboard:** A personalized dashboard for employees to view their own attendance records.
-- **Automatic Training:** The face recognition model updates automatically when new employee photos are added—no manual training required.
+- **Automatic Training:** The face recognition model updates automatically when new employee photos are added—no manual training required. Use `make evaluate` or `make report` any time you want to review metrics.
 - **Performance Optimized:** Utilizes the efficient "Facenet" model and "SSD" detector for a fast and responsive recognition experience.
 - **Continuous Integration:** Includes a GitHub Actions workflow to automatically run tests, ensuring code quality and stability.
 


### PR DESCRIPTION
## Summary
- replace the Makefile train target with a descriptive message about automatic training and point to evaluation commands
- update the README and developer guide to reinforce the automatic training workflow and direct users to evaluation/report targets

## Testing
- make -n train

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690df3dc956c8330a55b370cf1e4b63e)