### PR TITLE
Add shared webcam manager and refactor attendance streaming

### DIFF
--- a/recognition/webcam_manager.py
+++ b/recognition/webcam_manager.py
@@ -1,0 +1,175 @@
+"""Thread-safe shared webcam manager used across attendance routines."""
+
+from __future__ import annotations
+
+import atexit
+import threading
+import time
+from typing import Optional, Tuple
+
+import numpy as np
+from imutils.video import VideoStream
+
+
+class _FrameConsumer:
+    """Context manager handed out by :class:`WebcamManager` to read frames."""
+
+    def __init__(self, manager: "WebcamManager") -> None:
+        self._manager = manager
+        self._last_frame_id = -1
+        self._active = False
+
+    def __enter__(self) -> "_FrameConsumer":  # pragma: no cover - trivial
+        self._manager._register_consumer()
+        self._active = True
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+
+    def close(self) -> None:
+        if self._active:
+            self._manager._release_consumer()
+            self._active = False
+
+    def read(self, timeout: Optional[float] = 1.0) -> Optional[np.ndarray]:
+        """Return the next frame or ``None`` if no frame is available."""
+
+        if not self._active:
+            return None
+
+        frame, frame_id = self._manager._wait_for_frame(self._last_frame_id, timeout)
+        if frame is not None:
+            self._last_frame_id = frame_id
+        return frame
+
+
+class WebcamManager:
+    """Shared webcam manager to avoid reinitialising the camera per request."""
+
+    def __init__(self, src: int = 0, warmup_time: float = 2.0) -> None:
+        self._src = src
+        self._warmup_time = max(0.0, warmup_time)
+        self._stream: Optional[VideoStream] = None
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._frame_lock = threading.Condition()
+        self._latest_frame: Optional[np.ndarray] = None
+        self._latest_frame_id = 0
+        self._consumer_lock = threading.Lock()
+        self._consumer_count = 0
+
+    # -- lifecycle -----------------------------------------------------
+
+    def start(self) -> None:
+        if self._running:
+            return
+
+        self._stream = VideoStream(src=self._src).start()
+        if self._warmup_time:
+            time.sleep(self._warmup_time)
+
+        self._running = True
+        self._thread = threading.Thread(target=self._capture_loop, daemon=True)
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        if not self._running:
+            return
+
+        self._running = False
+        with self._frame_lock:
+            self._frame_lock.notify_all()
+
+        if self._thread:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+        if self._stream:
+            try:
+                self._stream.stop()
+            finally:
+                self._stream = None
+
+        self._latest_frame = None
+        self._latest_frame_id = 0
+
+    # -- consumer helpers ---------------------------------------------
+
+    def frame_consumer(self) -> _FrameConsumer:
+        self.start()
+        return _FrameConsumer(self)
+
+    def _register_consumer(self) -> None:
+        with self._consumer_lock:
+            self._consumer_count += 1
+
+    def _release_consumer(self) -> None:
+        with self._consumer_lock:
+            self._consumer_count = max(0, self._consumer_count - 1)
+
+    # -- frame handling ------------------------------------------------
+
+    def _capture_loop(self) -> None:
+        assert self._stream is not None  # pragma: no cover - defensive
+
+        while self._running and self._stream is not None:
+            frame = self._stream.read()
+            if frame is None:
+                time.sleep(0.01)
+                continue
+
+            with self._frame_lock:
+                self._latest_frame = frame.copy()
+                self._latest_frame_id += 1
+                self._frame_lock.notify_all()
+
+    def _wait_for_frame(
+        self, after_frame_id: int, timeout: Optional[float]
+    ) -> Tuple[Optional[np.ndarray], int]:
+        end_time = None if timeout is None else time.time() + max(timeout, 0.0)
+
+        with self._frame_lock:
+            while self._running and self._latest_frame_id <= after_frame_id:
+                if timeout is None:
+                    self._frame_lock.wait()
+                    continue
+
+                remaining = end_time - time.time()
+                if remaining <= 0:
+                    break
+                self._frame_lock.wait(timeout=remaining)
+
+            if self._latest_frame is None or self._latest_frame_id <= after_frame_id:
+                return None, after_frame_id
+
+            frame_copy = self._latest_frame.copy()
+            return frame_copy, self._latest_frame_id
+
+
+_manager_lock = threading.Lock()
+_manager_instance: Optional[WebcamManager] = None
+
+
+def get_webcam_manager() -> WebcamManager:
+    """Return the shared :class:`WebcamManager` instance."""
+
+    global _manager_instance
+    if _manager_instance is None:
+        with _manager_lock:
+            if _manager_instance is None:
+                _manager_instance = WebcamManager()
+    return _manager_instance
+
+
+def reset_webcam_manager() -> None:
+    """Shutdown the shared manager and remove the singleton reference."""
+
+    global _manager_instance
+    if _manager_instance is not None:
+        _manager_instance.shutdown()
+    _manager_instance = None
+
+
+atexit.register(reset_webcam_manager)
+

--- a/tests/recognition/test_webcam_manager.py
+++ b/tests/recognition/test_webcam_manager.py
@@ -1,0 +1,61 @@
+"""Tests for the shared webcam manager lifecycle."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+from django.test import SimpleTestCase
+
+from recognition.webcam_manager import get_webcam_manager, reset_webcam_manager
+
+
+class WebcamManagerLifecycleTests(SimpleTestCase):
+    """Ensure the shared webcam manager releases resources cleanly."""
+
+    def tearDown(self) -> None:
+        reset_webcam_manager()
+        return super().tearDown()
+
+    @patch("recognition.webcam_manager.VideoStream")
+    def test_shutdown_stops_underlying_stream(self, mock_videostream):
+        frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+        stream = MagicMock()
+        stream.start.return_value = stream
+        stream.read.side_effect = lambda: frame
+        mock_videostream.return_value = stream
+
+        manager = get_webcam_manager()
+        with manager.frame_consumer() as consumer:
+            self.assertIsNotNone(consumer.read(timeout=0.1))
+
+        manager.shutdown()
+        stream.stop.assert_called_once()
+
+    @patch("recognition.webcam_manager.VideoStream")
+    def test_reset_disposes_existing_instance(self, mock_videostream):
+        frame = np.zeros((1, 1, 3), dtype=np.uint8)
+
+        stream_one = MagicMock()
+        stream_one.start.return_value = stream_one
+        stream_one.read.side_effect = lambda: frame
+
+        stream_two = MagicMock()
+        stream_two.start.return_value = stream_two
+        stream_two.read.side_effect = lambda: frame
+
+        mock_videostream.side_effect = [stream_one, stream_two]
+
+        manager_first = get_webcam_manager()
+        with manager_first.frame_consumer() as consumer:
+            self.assertIsNotNone(consumer.read(timeout=0.1))
+
+        reset_webcam_manager()
+        stream_one.stop.assert_called_once()
+
+        manager_second = get_webcam_manager()
+        self.assertIsNot(manager_first, manager_second)
+        with manager_second.frame_consumer() as consumer:
+            self.assertIsNotNone(consumer.read(timeout=0.1))
+


### PR DESCRIPTION
## Summary
- add a thread-safe webcam manager singleton that shares VideoStream frames across requests and provides shutdown hooks
- update `_mark_attendance` and `mark_attendance_view` to consume frames from the shared manager with locking
- adjust tests to use the new manager abstraction and cover lifecycle shutdown behaviour

## Testing
- `pytest tests/recognition -q --override-ini addopts=` *(fails: missing dependency `cryptography`)*
- `pytest tests/recognition/test_webcam_manager.py -q --override-ini addopts=` *(fails: missing system library `libGL.so.1` required by OpenCV)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69102eb4460c83308a8c543067e7f66b)