### PR TITLE
Secure dataset cache with face data encryption helper

### DIFF
--- a/attendance_system_facial_recognition/settings.py
+++ b/attendance_system_facial_recognition/settings.py
@@ -91,6 +91,31 @@ def _load_data_encryption_key() -> bytes:
 
 DATA_ENCRYPTION_KEY = _load_data_encryption_key()
 
+
+def _load_face_data_encryption_key() -> bytes:
+    """Load the Fernet key used to encrypt cached facial encodings."""
+
+    key = os.environ.get("FACE_DATA_ENCRYPTION_KEY")
+    if key:
+        key_bytes = key.encode()
+        try:
+            Fernet(key_bytes)
+        except (ValueError, TypeError) as exc:  # pragma: no cover - defensive programming
+            raise ImproperlyConfigured(
+                "FACE_DATA_ENCRYPTION_KEY must be a valid 32-byte base64-encoded Fernet key."
+            ) from exc
+        return key_bytes
+
+    if DEBUG or TESTING:
+        return Fernet.generate_key()
+
+    raise ImproperlyConfigured(
+        "FACE_DATA_ENCRYPTION_KEY environment variable must be set in production environments."
+    )
+
+
+FACE_DATA_ENCRYPTION_KEY = _load_face_data_encryption_key()
+
 # ALLOWED_HOSTS: A list of strings representing the host/domain names that this Django site can serve.
 # When DJANGO_DEBUG is False the value must be explicitly provided.
 allowed_hosts_env = os.environ.get("DJANGO_ALLOWED_HOSTS")

--- a/src/common/__init__.py
+++ b/src/common/__init__.py
@@ -1,6 +1,13 @@
 """Common utilities for reproducibility, security, and shared functions."""
 
 from .encryption import InvalidToken, decrypt_bytes, encrypt_bytes
+from .face_data_encryption import FaceDataEncryption
 from .seeding import set_global_seed
 
-__all__ = ["set_global_seed", "encrypt_bytes", "decrypt_bytes", "InvalidToken"]
+__all__ = [
+    "set_global_seed",
+    "encrypt_bytes",
+    "decrypt_bytes",
+    "InvalidToken",
+    "FaceDataEncryption",
+]

--- a/src/common/face_data_encryption.py
+++ b/src/common/face_data_encryption.py
@@ -1,0 +1,73 @@
+"""Helpers for encrypting sensitive face data encodings."""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+from cryptography.fernet import Fernet, InvalidToken
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+BytesLike = Union[bytes, bytearray, memoryview]
+
+
+class FaceDataEncryption:
+    """Provide Fernet-backed helpers for encrypting facial encodings."""
+
+    def __init__(self, key: BytesLike | str | None = None) -> None:
+        self._key_override = key
+        self._cipher: Fernet | None = None
+
+    def _resolve_key(self) -> bytes:
+        """Return the Fernet key configured for face data encryption."""
+
+        key = self._key_override
+        if key is None:
+            key = getattr(settings, "FACE_DATA_ENCRYPTION_KEY", None)
+        if key is None:
+            raise ImproperlyConfigured("FACE_DATA_ENCRYPTION_KEY is not configured.")
+        if isinstance(key, str):
+            key_bytes = key.encode()
+        else:
+            key_bytes = bytes(key)
+        try:
+            Fernet(key_bytes)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - defensive programming
+            raise ImproperlyConfigured("FACE_DATA_ENCRYPTION_KEY is invalid.") from exc
+        return key_bytes
+
+    def _get_cipher(self) -> Fernet:
+        if self._cipher is None:
+            self._cipher = Fernet(self._resolve_key())
+        return self._cipher
+
+    def encrypt(self, data: BytesLike) -> bytes:
+        """Encrypt an arbitrary payload of bytes."""
+
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError("encrypt expects a bytes-like object")
+        return self._get_cipher().encrypt(bytes(data))
+
+    def decrypt(self, token: BytesLike) -> bytes:
+        """Decrypt an encrypted payload."""
+
+        if not isinstance(token, (bytes, bytearray, memoryview)):
+            raise TypeError("decrypt expects a bytes-like object")
+        return self._get_cipher().decrypt(bytes(token))
+
+    def encrypt_encoding(self, encoding: np.ndarray) -> bytes:
+        """Encrypt a numpy facial encoding array."""
+
+        if not isinstance(encoding, np.ndarray):
+            raise TypeError("encrypt_encoding expects a numpy.ndarray")
+        return self.encrypt(encoding.astype(np.float64).tobytes())
+
+    def decrypt_encoding(self, encrypted_data: BytesLike, dtype: np.dtype = np.float64) -> np.ndarray:
+        """Decrypt an encrypted encoding back into a numpy array."""
+
+        decrypted = self.decrypt(encrypted_data)
+        return np.frombuffer(decrypted, dtype=dtype)
+
+
+__all__ = ["FaceDataEncryption", "InvalidToken"]


### PR DESCRIPTION
## Summary
- add a FaceDataEncryption helper for Fernet-based facial encoding encryption
- load and validate the FACE_DATA_ENCRYPTION_KEY setting with debug/test defaults
- encrypt dataset embedding cache entries and extend tests to cover round-trips

## Testing
- pytest --override-ini=addopts= tests/recognition/test_dataset_cache.py tests/recognition/test_encryption_workflow.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106746569c83308c9e081ca247e0e4)