### PR TITLE
Add rate-limited face recognition API endpoint

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -36,6 +36,7 @@ This document outlines all the URL patterns for the project and explains the pur
 |-------------------------------|------------------------------------|------------------------------|--------------------------------------------------------|
 | `/mark_your_attendance`       | `recog_views.mark_your_attendance` | `mark-your-attendance`       | Handles marking time-in using face recognition.        |
 | `/mark_your_attendance_out`   | `recog_views.mark_your_attendance_out` | `mark-your-attendance-out`   | Handles marking time-out using face recognition.       |
+| `/api/face-recognition/`      | `recog_views.FaceRecognitionAPI`    | `face-recognition-api`       | JSON API that evaluates submitted embeddings or images and returns the closest enrolled identity. Rate limited to 5 requests per minute per IP address. |
 
 ## Attendance Viewing
 

--- a/attendance_system_facial_recognition/urls.py
+++ b/attendance_system_facial_recognition/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
         recog_views.mark_your_attendance_out,
         name="mark-your-attendance-out",
     ),
+    path(
+        "api/face-recognition/",
+        recog_views.FaceRecognitionAPI.as_view(),
+        name="face-recognition-api",
+    ),
     # Attendance Viewing
     path(
         "view_attendance_home",

--- a/tests/recognition/test_face_recognition_api.py
+++ b/tests/recognition/test_face_recognition_api.py
@@ -1,0 +1,106 @@
+import json
+import os
+import sys
+from unittest.mock import MagicMock
+
+import django
+import numpy as np
+import pytest
+from django.core.cache import cache
+from django.test import override_settings
+from django.urls import reverse
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "attendance_system_facial_recognition.settings")
+
+sys.modules.setdefault("cv2", MagicMock())
+
+django.setup()
+
+from recognition import views
+
+
+pytestmark = pytest.mark.django_db
+
+
+@override_settings(
+    RECOGNITION_DISTANCE_THRESHOLD=0.5,
+    DEEPFACE_OPTIMIZATIONS={
+        "distance_metric": "euclidean_l2",
+        "model": "Facenet",
+        "detector_backend": "opencv",
+        "enforce_detection": False,
+        "anti_spoofing": False,
+    },
+)
+def test_face_recognition_api_returns_match(client, monkeypatch):
+    cache.clear()
+
+    monkeypatch.setattr(
+        views,
+        "_load_dataset_embeddings_for_matching",
+        lambda *args, **kwargs: [
+            {
+                "embedding": np.array([0.1, 0.2, 0.3], dtype=float),
+                "username": "alice",
+                "identity": "alice/sample.jpg",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        views,
+        "_find_closest_dataset_match",
+        lambda embedding, dataset, metric: ("alice", 0.05, "alice/sample.jpg"),
+    )
+
+    url = reverse("face-recognition-api")
+    payload = json.dumps({"embedding": [0.1, 0.2, 0.3]})
+    response = client.post(url, data=payload, content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["recognized"] is True
+    assert data["username"] == "alice"
+    assert data["identity"] == "alice/sample.jpg"
+    assert data["distance_metric"] == "euclidean_l2"
+    assert pytest.approx(data["distance"]) == 0.05
+
+
+@override_settings(
+    RECOGNITION_DISTANCE_THRESHOLD=0.5,
+    DEEPFACE_OPTIMIZATIONS={
+        "distance_metric": "euclidean_l2",
+        "model": "Facenet",
+        "detector_backend": "opencv",
+        "enforce_detection": False,
+        "anti_spoofing": False,
+    },
+)
+def test_face_recognition_api_rate_limit(client, monkeypatch):
+    cache.clear()
+
+    monkeypatch.setattr(
+        views,
+        "_load_dataset_embeddings_for_matching",
+        lambda *args, **kwargs: [
+            {
+                "embedding": np.array([0.1, 0.2, 0.3], dtype=float),
+                "username": "alice",
+                "identity": "alice/sample.jpg",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        views,
+        "_find_closest_dataset_match",
+        lambda embedding, dataset, metric: ("alice", 0.05, "alice/sample.jpg"),
+    )
+
+    url = reverse("face-recognition-api")
+    payload = json.dumps({"embedding": [0.1, 0.2, 0.3]})
+
+    for _ in range(5):
+        ok_response = client.post(url, data=payload, content_type="application/json")
+        assert ok_response.status_code == 200
+
+    limited = client.post(url, data=payload, content_type="application/json")
+    assert limited.status_code == 429


### PR DESCRIPTION
## Summary
- implement a `FaceRecognitionAPI` class-based view that accepts embeddings or images, reuses existing recognition helpers, and enforces IP-based rate limiting
- expose the new API at `/api/face-recognition/` and document the endpoint in the API reference
- cover the endpoint with integration tests exercising success and rate-limit behaviour

## Testing
- pytest tests/recognition/test_face_recognition_api.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691068b7ecfc8330af15a8924b798f66)