### PR TITLE
Add reusable camera manager and integrate preview modal

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -114,3 +114,29 @@ CI pipelines must export `DATABASE_URL` before running `pytest` so Django connec
 ```
 
 Running tests against Postgres ensures migrations stay compatible with the production backend and catches issues that do not appear with SQLite.
+
+## 8. Frontend utilities
+
+### CameraManager helper
+
+Use the `CameraManager` utility (`recognition/static/js/camera.js`) to initialise and tear down shared camera streams in templates. The helper reuses a single `MediaStream` and automatically releases tracks when you call `stop()`.
+
+```html
+{% load static %}
+<script type="module">
+  import { CameraManager } from "{% static 'js/camera.js' %}";
+
+  const cameraManager = new CameraManager();
+  const preview = document.querySelector("video");
+
+  async function openPreview() {
+    await cameraManager.start(preview);
+  }
+
+  function closePreview() {
+    cameraManager.stop();
+  }
+</script>
+```
+
+Always pair preview components with lifecycle events (`hidden.bs.modal`, `beforeunload`, etc.) that call `stop()` so the browser can release the webcam promptly.

--- a/recognition/static/js/camera.js
+++ b/recognition/static/js/camera.js
@@ -1,0 +1,168 @@
+"use strict";
+
+/**
+ * CameraManager centralises MediaStream lifecycle management for templates that
+ * provide camera previews or capture workflows.
+ *
+ * Basic usage:
+ * ```javascript
+ * import { CameraManager } from "{% static 'js/camera.js' %}";
+ * const manager = new CameraManager();
+ * await manager.start(document.querySelector("video"));
+ * // ... later when the UI closes
+ * manager.stop();
+ * ```
+ *
+ * The manager ensures the same stream instance is reused across multiple
+ * invocations and guarantees that tracks are stopped during cleanup.
+ */
+export class CameraManager {
+  constructor(defaultConstraints) {
+    this._defaultConstraints =
+      defaultConstraints || CameraManager.defaultConstraints;
+    this._stream = null;
+    this._initialising = null;
+    this._videoElements = new Set();
+  }
+
+  /**
+   * Retrieve an active stream and optionally attach it to a video element.
+   *
+   * @param {HTMLVideoElement} [videoElement] - Element that should render the stream.
+   * @param {MediaStreamConstraints} [constraints] - Custom constraints for `getUserMedia`.
+   * @returns {Promise<MediaStream>} The active MediaStream instance.
+   */
+  async start(videoElement, constraints) {
+    const stream = await this.getStream(constraints);
+    if (videoElement) {
+      this.attach(videoElement);
+    }
+    return stream;
+  }
+
+  /**
+   * Return a MediaStream, initialising it if necessary.
+   *
+   * @param {MediaStreamConstraints} [constraints] - Optional constraints override.
+   * @returns {Promise<MediaStream>} The ready MediaStream instance.
+   */
+  async getStream(constraints) {
+    const desiredConstraints = constraints || this._defaultConstraints;
+    if (constraints) {
+      this._defaultConstraints = constraints;
+    }
+
+    if (this._stream) {
+      return this._stream;
+    }
+
+    if (!this._initialising) {
+      this._initialising = this._requestStream(desiredConstraints);
+    }
+
+    return this._initialising;
+  }
+
+  /**
+   * Attach the active stream to a video element.
+   *
+   * @param {HTMLVideoElement} videoElement - Element that should render the stream.
+   */
+  attach(videoElement) {
+    if (!videoElement) {
+      return;
+    }
+
+    this._videoElements.add(videoElement);
+
+    if (!this._stream) {
+      return;
+    }
+
+    // Ensure the element always reflects the active stream.
+    videoElement.srcObject = this._stream;
+    if (typeof videoElement.play === "function") {
+      const playResult = videoElement.play();
+      if (playResult && typeof playResult.catch === "function") {
+        playResult.catch(() => {
+          /* Ignore autoplay errors caused by browser policies. */
+        });
+      }
+    }
+  }
+
+  /**
+   * Detach a video element from the active stream.
+   *
+   * @param {HTMLVideoElement} videoElement - Element previously passed to `attach`.
+   */
+  detach(videoElement) {
+    if (!videoElement) {
+      return;
+    }
+
+    this._videoElements.delete(videoElement);
+    if (typeof videoElement.pause === "function") {
+      videoElement.pause();
+    }
+    videoElement.srcObject = null;
+  }
+
+  /**
+   * Stop all tracks and release the managed MediaStream.
+   */
+  stop() {
+    this._videoElements.forEach((videoElement) => {
+      if (typeof videoElement.pause === "function") {
+        videoElement.pause();
+      }
+      videoElement.srcObject = null;
+    });
+    this._videoElements.clear();
+
+    if (this._stream) {
+      this._stream.getTracks().forEach((track) => track.stop());
+      this._stream = null;
+    }
+    this._initialising = null;
+  }
+
+  /**
+   * Dispose the manager and clean up all resources.
+   */
+  dispose() {
+    this.stop();
+  }
+
+  async _requestStream(constraints) {
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      this._initialising = null;
+      throw new Error("Camera access is not supported in this browser.");
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      this._stream = stream;
+      return stream;
+    } catch (error) {
+      this._stream = null;
+      throw error;
+    } finally {
+      this._initialising = null;
+    }
+  }
+
+  /**
+   * Default video constraints used when none are provided.
+   */
+  static get defaultConstraints() {
+    return {
+      video: {
+        width: { ideal: 640 },
+        height: { ideal: 480 },
+        facingMode: "user",
+      },
+      audio: false,
+    };
+  }
+}

--- a/recognition/templates/recognition/add_photos.html
+++ b/recognition/templates/recognition/add_photos.html
@@ -1,5 +1,5 @@
 {% extends "recognition/base.html" %}
-{% load crispy_forms_tags %}
+{% load static crispy_forms_tags %}
 
 {% block title %}Add Photos - Smart Attendance System{% endblock %}
 
@@ -28,6 +28,14 @@
                         <button class="btn btn-primary" type="submit" style="padding: var(--space-4) var(--space-6); font-size: var(--font-size-lg);">
                             <i class="fas fa-camera" aria-hidden="true"></i> Start Camera
                         </button>
+                        <button
+                            class="btn btn-outline-primary"
+                            type="button"
+                            data-camera-preview-trigger
+                            style="padding: var(--space-4) var(--space-6); font-size: var(--font-size-lg);"
+                        >
+                            <i class="fas fa-video" aria-hidden="true"></i> Preview Camera
+                        </button>
                         <a href="{% url 'dashboard' %}" class="btn btn-secondary" style="padding: var(--space-4) var(--space-6);">
                             <i class="fas fa-arrow-left" aria-hidden="true"></i> Back to Dashboard
                         </a>
@@ -35,6 +43,45 @@
                 </form>
             </div>
         </article>
+
+        <!-- Camera Preview Modal -->
+        <div
+            class="modal fade"
+            id="cameraPreviewModal"
+            tabindex="-1"
+            aria-labelledby="cameraPreviewModalLabel"
+            aria-hidden="true"
+        >
+            <div class="modal-dialog modal-dialog-centered modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h2 class="modal-title h5" id="cameraPreviewModalLabel">Camera Preview</h2>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="ratio ratio-4x3 bg-dark rounded" style="--bs-aspect-ratio: 75%;">
+                            <video
+                                id="cameraPreview"
+                                class="w-100 h-100 rounded"
+                                autoplay
+                                muted
+                                playsinline
+                                data-camera-preview
+                            ></video>
+                        </div>
+                        <div class="alert alert-danger mt-3 d-none" role="alert" data-camera-error></div>
+                        <p class="text-muted small mt-3 mb-0">
+                            Grant camera permissions when prompted. The preview stops automatically once you close this dialog.
+                        </p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                            <i class="fas fa-xmark" aria-hidden="true"></i> Close Preview
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
         
         <!-- Instructions Card -->
         <div class="card mt-4" style="margin-top: var(--space-6); border-left: 4px solid var(--color-info);">
@@ -71,4 +118,82 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_scripts %}
+<script type="module">
+    import { CameraManager } from "{% static 'js/camera.js' %}";
+
+    document.addEventListener("DOMContentLoaded", () => {
+        const modalElement = document.getElementById("cameraPreviewModal");
+        const previewButton = document.querySelector("[data-camera-preview-trigger]");
+        const errorAlert = modalElement?.querySelector("[data-camera-error]");
+        const previewVideo = modalElement?.querySelector("[data-camera-preview]");
+
+        if (!modalElement || !window.bootstrap) {
+            return;
+        }
+
+        const cameraManager = new CameraManager();
+        const bootstrapModal = window.bootstrap.Modal.getOrCreateInstance(modalElement);
+
+        const hideError = () => {
+            if (errorAlert) {
+                errorAlert.classList.add("d-none");
+                errorAlert.textContent = "";
+            }
+        };
+
+        const showError = (message) => {
+            if (!errorAlert) {
+                return;
+            }
+            errorAlert.textContent = message;
+            errorAlert.classList.remove("d-none");
+        };
+
+        if (previewButton) {
+            const cameraSupported = Boolean(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);
+            if (!cameraSupported) {
+                previewButton.disabled = true;
+                previewButton.title = "Camera preview is not supported in this browser.";
+            }
+
+            previewButton.addEventListener("click", (event) => {
+                event.preventDefault();
+                hideError();
+                bootstrapModal.show();
+            });
+        }
+
+        modalElement.addEventListener("shown.bs.modal", async () => {
+            hideError();
+            if (!previewVideo) {
+                return;
+            }
+
+            try {
+                await cameraManager.start(previewVideo);
+            } catch (error) {
+                cameraManager.stop();
+                showError(error?.message || "Unable to access the camera. Please check your browser permissions.");
+            }
+        });
+
+        const teardown = () => {
+            hideError();
+            cameraManager.stop();
+        };
+
+        modalElement.addEventListener("hidden.bs.modal", teardown);
+
+        window.addEventListener("beforeunload", () => cameraManager.stop());
+        window.addEventListener("pagehide", () => cameraManager.stop());
+        document.addEventListener("visibilitychange", () => {
+            if (document.visibilityState === "hidden") {
+                cameraManager.stop();
+            }
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable CameraManager helper that reuses MediaStream instances and cleans up tracks
- wire the add photos workflow to the new helper with a Bootstrap preview modal and lifecycle cleanup
- document how to use the CameraManager in the developer guide for future frontend work

## Testing
- `pytest -o addopts= recognition/tests.py` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69106aef63d88330822e90b3c458a6f5)