### PR TITLE
Refactor settings module into a package with production overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ For more detailed information, please refer to the full documentation:
 
 ## Deployment Configuration
 
-When deploying to staging or production, configure the following environment variables so that session cookies remain secure and expire after periods of inactivity. Boolean values accept `1`, `true`, `yes`, or `on` (case-insensitive).
+When deploying to staging or production, configure the following environment variables so that session cookies remain secure and expire after periods of inactivity. Boolean values accept `1`, `true`, `yes`, or `on` (case-insensitive). Use the development settings module (`attendance_system_facial_recognition.settings`) locally and for automated tests. Production deployments should set `DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.production` so the hardened database configuration is loaded.
 
 | Environment variable | Purpose | Recommended staging value | Recommended production value |
 | --- | --- | --- | --- |

--- a/attendance_system_facial_recognition/settings/__init__.py
+++ b/attendance_system_facial_recognition/settings/__init__.py
@@ -1,0 +1,3 @@
+"""Settings package exposing the default development configuration."""
+
+from .base import *  # noqa: F401,F403

--- a/attendance_system_facial_recognition/settings/base.py
+++ b/attendance_system_facial_recognition/settings/base.py
@@ -17,7 +17,7 @@ from cryptography.fernet import Fernet
 
 # Define the project's base directory.
 # `BASE_DIR` points to the root of the Django project.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 # --- Security Settings ---

--- a/attendance_system_facial_recognition/settings/production.py
+++ b/attendance_system_facial_recognition/settings/production.py
@@ -1,0 +1,35 @@
+"""Production settings overriding the defaults with hardened options."""
+
+from __future__ import annotations
+
+import os
+
+from . import base as base_settings
+from .base import *  # noqa: F401,F403
+
+
+def _get_db_setting(var_name: str, *, default: str | None = None) -> str:
+    """Return a database setting from the environment or the provided default."""
+
+    value = os.environ.get(var_name)
+    if value:
+        return value
+    if default is None:
+        raise ImproperlyConfigured(
+            f"{var_name} must be set when using the production settings module."
+        )
+    return default
+
+
+DATABASES["default"] = {
+    "ENGINE": "django.db.backends.postgresql",
+    "NAME": _get_db_setting("DB_NAME", default="attendance"),
+    "USER": _get_db_setting("DB_USER", default="attendance"),
+    "PASSWORD": _get_db_setting("DB_PASSWORD", default="attendance"),
+    "HOST": _get_db_setting("DB_HOST", default="localhost"),
+    "PORT": _get_db_setting("DB_PORT", default="5432"),
+    "CONN_MAX_AGE": base_settings._parse_int_env("DB_CONN_MAX_AGE", 600, minimum=0),
+}
+
+if base_settings._get_bool_env("DB_SSL_REQUIRE", default=False):
+    DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = "require"

--- a/attendance_system_facial_recognition/wsgi.py
+++ b/attendance_system_facial_recognition/wsgi.py
@@ -11,6 +11,12 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "attendance_system_facial_recognition.settings")
+# WSGI is typically invoked by the production application server, so default to
+# the hardened production settings. Developers running local WSGI servers can
+# override this by exporting DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.
+os.environ.setdefault(
+    "DJANGO_SETTINGS_MODULE",
+    "attendance_system_facial_recognition.settings.production",
+)
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -5,7 +5,11 @@ import sys
 
 
 def main():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "attendance_system_facial_recognition.settings")
+    # Default to the development/test settings. Production deployments should
+    # export DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.production.
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "attendance_system_facial_recognition.settings"
+    )
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/tests/settings/test_production.py
+++ b/tests/settings/test_production.py
@@ -1,0 +1,74 @@
+"""Smoke tests for the production settings module."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _reload_production_settings():
+    """Force a reload of the production settings module for isolation."""
+
+    for module in [
+        "attendance_system_facial_recognition.settings.production",
+        "attendance_system_facial_recognition.settings.base",
+        "attendance_system_facial_recognition.settings",
+    ]:
+        sys.modules.pop(module, None)
+    return importlib.import_module("attendance_system_facial_recognition.settings.production")
+
+
+def test_production_database_configuration(monkeypatch):
+    fake_celery = types.ModuleType("celery")
+
+    class _DummyCelery:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def config_from_object(self, *args, **kwargs):
+            return None
+
+        def autodiscover_tasks(self, *args, **kwargs):
+            return None
+
+    fake_celery.Celery = _DummyCelery
+    monkeypatch.setitem(sys.modules, "celery", fake_celery)
+
+    fake_cryptography = types.ModuleType("cryptography")
+    fake_fernet = types.ModuleType("cryptography.fernet")
+
+    class _DummyFernet:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        @staticmethod
+        def generate_key() -> bytes:
+            return b"0" * 32
+
+    fake_fernet.Fernet = _DummyFernet
+    fake_cryptography.fernet = fake_fernet
+    monkeypatch.setitem(sys.modules, "cryptography", fake_cryptography)
+    monkeypatch.setitem(sys.modules, "cryptography.fernet", fake_fernet)
+
+    monkeypatch.setenv(
+        "DJANGO_SETTINGS_MODULE",
+        "attendance_system_facial_recognition.settings.production",
+    )
+    monkeypatch.setenv("DB_NAME", "ci_db")
+    monkeypatch.setenv("DB_USER", "ci_user")
+    monkeypatch.setenv("DB_PASSWORD", "ci_password")
+    monkeypatch.setenv("DB_HOST", "postgres")
+    monkeypatch.setenv("DB_PORT", "6543")
+    monkeypatch.setenv("DB_CONN_MAX_AGE", "120")
+
+    settings = _reload_production_settings()
+
+    database = settings.DATABASES["default"]
+    assert database["ENGINE"] == "django.db.backends.postgresql"
+    assert database["NAME"] == "ci_db"
+    assert database["USER"] == "ci_user"
+    assert database["PASSWORD"] == "ci_password"
+    assert database["HOST"] == "postgres"
+    assert database["PORT"] == "6543"
+    assert database["CONN_MAX_AGE"] == 120


### PR DESCRIPTION
## Summary
- split the legacy settings module into a package with a shared base module
- add dedicated production settings that configure PostgreSQL via environment variables
- document the new DJANGO_SETTINGS_MODULE usage and add a smoke test for the production database config

## Testing
- pytest tests/settings/test_production.py -o addopts=


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691072ed5c1883308e61f2e0817c83b7)