### PR TITLE
Add Silk performance monitoring configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ This project is a fully refactored and modernized smart attendance system that l
     ```
     This ensures the generated icons, `manifest.json`, and `sw.js` are published alongside the rest of the static files when you deploy with WhiteNoise or another static file server.
 
+## Performance Monitoring
+
+Silk is bundled to profile database queries, view timings, and cache usage without leaving the Django admin. The dependency is already pinned in `requirements.txt`/`pyproject.toml`, so installing the project requirements pulls it in automatically.
+
+1. **Apply Silk migrations** after installing dependencies any time new environments are set up:
+   ```bash
+   python manage.py migrate
+   ```
+   This creates the `silk_*` tables used to persist profiling results.
+2. **Accessing the dashboard:**
+   - In development (`DJANGO_DEBUG=1`) visit `http://127.0.0.1:8000/silk/` to inspect live profiles.
+   - In non-debug deployments Silk requires authentication and staff status. Log in with a staff or superuser account before visiting `/silk/`; non-staff users receive a permission error and unauthenticated visitors are redirected to the login page.
+3. **Production guardrails:** keep the middleware enabled only when you actively need profiling, and clear the Silk tables regularly in long-running environments to manage database size.
+
 ## Documentation
 
 For more detailed information, please refer to the full documentation:

--- a/attendance_system_facial_recognition/settings/base.py
+++ b/attendance_system_facial_recognition/settings/base.py
@@ -157,6 +157,7 @@ INSTALLED_APPS = [
     "users.apps.UsersConfig",
     "recognition.apps.RecognitionConfig",
     # Third-party packages
+    "silk",
     "django_rq",
     "django_ratelimit",
     "crispy_forms",
@@ -171,6 +172,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "silk.middleware.SilkyMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -331,6 +333,19 @@ LOGOUT_REDIRECT_URL = "home"
 
 # The default URL to redirect to after a user logs in.
 LOGIN_REDIRECT_URL = "dashboard"
+
+# --- Performance Monitoring (django-silk) ---
+
+
+def _silky_staff_only(user) -> bool:
+    """Restrict Silk dashboards to authenticated staff members."""
+
+    return bool(user and user.is_authenticated and user.is_staff)
+
+
+SILKY_AUTHENTICATION = True
+SILKY_AUTHORISATION = True
+SILKY_PERMISSIONS = _silky_staff_only
 
 # --- Model Field Configuration ---
 

--- a/attendance_system_facial_recognition/urls.py
+++ b/attendance_system_facial_recognition/urls.py
@@ -13,7 +13,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.http import FileResponse, Http404
-from django.urls import path
+from django.urls import include, path
 
 from recognition import admin_views as recog_admin_views
 from recognition import views as recog_views
@@ -128,3 +128,6 @@ urlpatterns = [
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if settings.DEBUG or getattr(settings, "SILKY_AUTHORISATION", False):
+    urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "crispy-bootstrap5==2024.2",
     "django-ratelimit==4.1.0",
     "django-rq==2.10.2",
+    "django-silk==5.1.0",
     "django-pandas==0.6.7",
     "deepface==0.0.93",
     "imutils==0.5.4",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ crispy-bootstrap5==2024.2
 django-pandas==0.6.7
 django-ratelimit==4.1.0
 django-rq==2.10.2
+django-silk==5.1.0
 deepface==0.0.93
 imutils==0.5.4
 matplotlib==3.8.4


### PR DESCRIPTION
## Summary
- enable django-silk in the project configuration and restrict access to staff
- expose the silk dashboard URL when debugging or staff authorisation is enabled
- document profiling usage and add the dependency to the project manifests

## Testing
- python -m compileall attendance_system_facial_recognition

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bfd5b29c8330a609fa8417b3fd0f)