### PR TITLE
Add Sentry telemetry configuration for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,27 @@ The Progressive Web App resources are exposed at `/manifest.json` and `/sw.js`. 
 
 Ensure these variables are present in the staging and production deployment manifests (e.g., `.env` files, container secrets, or platform configuration) before rolling out new builds.
 
+### Observability and error tracking
+
+The production settings initialise [Sentry](https://sentry.io/) automatically when the DSN is supplied. Configure the following environment variables to tailor telemetry to each deployment target:
+
+| Environment variable | Purpose | Recommended staging value | Recommended production value |
+| --- | --- | --- | --- |
+| `SENTRY_DSN` | Enables Sentry ingestion for the project. | `https://<public>@sentry.io/<project>` | `https://<public>@sentry.io/<project>` |
+| `SENTRY_ENVIRONMENT` | Distinguishes environments inside the Sentry dashboards. | `staging` | `production` |
+| `SENTRY_RELEASE` | Associates events with build artefacts for source maps and regression tracking. | Git commit SHA | Git tag or release identifier |
+| `SENTRY_TRACES_SAMPLE_RATE` | Fraction (0.0–1.0) of requests captured for APM tracing. | `0.1` | `0.2` |
+| `SENTRY_PROFILES_SAMPLE_RATE` | Fraction (0.0–1.0) of traces that include profiling data. | `0.0` | `0.05` |
+| `SENTRY_SEND_DEFAULT_PII` | Toggle for sending user-identifiable attributes; defaults to scrubbing PII. | `false` | `false` |
+
+With `SENTRY_SEND_DEFAULT_PII` disabled, the integration strips cookies, authorisation headers, and user attributes before dispatching events so that production telemetry complies with internal privacy requirements. Operators that need richer context can opt in by setting `SENTRY_SEND_DEFAULT_PII=true` after completing a privacy impact assessment.
+
+#### Operational dashboards
+
+- **Issues**: Monitor unhandled exceptions and message breadcrumbs from the Sentry *Issues* dashboard. Pin the view filtered by `environment:production` to quickly detect regressions after each deployment.
+- **Performance**: Track request latency, throughput, and slow transactions with the *Performance* dashboard. Enable sampling via `SENTRY_TRACES_SAMPLE_RATE` to populate the charts and configure alerts for p95 latency regressions.
+- **Real-time**: For incident response, use Sentry's *Releases* view to correlate deploys with spikes in error volume, and subscribe the operations channel to release health alerts.
+
 ### Containerized deployment workflow
 
 The repository ships with a production-ready `Dockerfile` and Compose definition so you can build and run the stack with minimal host dependencies. The commands below assume Docker Engine 24+ and Docker Compose v2 are installed locally.

--- a/attendance_system_facial_recognition/settings/production.py
+++ b/attendance_system_facial_recognition/settings/production.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from . import base as base_settings
 from .base import *  # noqa: F401,F403
 from .base import DATABASES  # noqa: F401
+from .sentry import initialize_sentry
 
 
 def _get_db_setting(var_name: str, *, default: str | None = None) -> str:
@@ -36,3 +37,6 @@ DATABASES["default"] = {
 
 if base_settings._get_bool_env("DB_SSL_REQUIRE", default=False):
     DATABASES["default"].setdefault("OPTIONS", {})["sslmode"] = "require"
+
+
+initialize_sentry()

--- a/attendance_system_facial_recognition/settings/sentry.py
+++ b/attendance_system_facial_recognition/settings/sentry.py
@@ -1,0 +1,106 @@
+"""Sentry configuration helpers used by production deployments."""
+
+from __future__ import annotations
+
+import os
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from django.core.exceptions import ImproperlyConfigured
+
+import sentry_sdk
+from sentry_sdk.integrations import DidNotEnable
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from . import base as base_settings
+
+__all__ = ["initialize_sentry"]
+
+_SENSITIVE_HEADERS = {"authorization", "cookie", "set-cookie"}
+
+
+def _get_sample_rate(var_name: str, default: float) -> float:
+    """Return a tracing sample rate constrained between 0.0 and 1.0 inclusive."""
+
+    raw_value = os.environ.get(var_name)
+    if raw_value is None:
+        return default
+    try:
+        value = float(raw_value)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ImproperlyConfigured(
+            f"{var_name} must be a floating point number between 0.0 and 1.0."
+        ) from exc
+    if not 0.0 <= value <= 1.0:
+        raise ImproperlyConfigured(
+            f"{var_name} must be between 0.0 and 1.0 when provided."
+        )
+    return value
+
+
+def _scrub_headers(headers: Mapping[str, Any]) -> None:
+    """Remove sensitive headers from captured events in-place."""
+
+    for header in _SENSITIVE_HEADERS:
+        if header in headers:
+            headers[header] = "[Filtered]"
+
+
+def initialize_sentry() -> None:
+    """Initialise Sentry SDK when a DSN is supplied via the environment."""
+
+    dsn = os.environ.get("SENTRY_DSN")
+    if not dsn:
+        return
+
+    send_default_pii = base_settings._get_bool_env("SENTRY_SEND_DEFAULT_PII", default=False)
+
+    def _before_send(event: dict[str, Any], _hint: object | None) -> dict[str, Any] | None:
+        request = event.get("request")
+        if isinstance(request, dict):
+            headers = request.get("headers")
+            if isinstance(headers, Mapping):
+                _scrub_headers(headers)
+        if not send_default_pii:
+            event.pop("user", None)
+        return event
+
+    integrations = [
+        DjangoIntegration(transaction_style="url"),
+        LoggingIntegration(level=None, event_level=logging.ERROR),
+    ]
+
+    try:
+        from sentry_sdk.integrations.celery import CeleryIntegration
+    except (ImportError, DidNotEnable):  # pragma: no cover - optional dependency
+        CeleryIntegration = None
+    if CeleryIntegration is not None:
+        try:
+            integrations.append(CeleryIntegration())
+        except DidNotEnable:  # pragma: no cover - optional dependency
+            pass
+
+    try:
+        from sentry_sdk.integrations.redis import RedisIntegration
+    except ImportError:  # pragma: no cover - optional dependency
+        RedisIntegration = None
+    if RedisIntegration is not None:
+        integrations.append(RedisIntegration())
+
+    traces_sample_rate = _get_sample_rate("SENTRY_TRACES_SAMPLE_RATE", default=0.0)
+    profiles_sample_rate = _get_sample_rate("SENTRY_PROFILES_SAMPLE_RATE", default=0.0)
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("SENTRY_ENVIRONMENT", "production"),
+        release=os.environ.get("SENTRY_RELEASE"),
+        integrations=integrations,
+        enable_tracing=True,
+        traces_sample_rate=traces_sample_rate,
+        profiles_sample_rate=profiles_sample_rate,
+        send_default_pii=send_default_pii,
+        before_send=_before_send,
+    )
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "matplotlib==3.8.4",
     "celery==5.4.0",
     "redis==5.2.1",
+    "sentry-sdk[django]==2.43.0",
     "seaborn==0.13.2",
     "Pillow==10.3.0",
     "opencv-python==4.9.0.80",

--- a/requirements.frozen.txt
+++ b/requirements.frozen.txt
@@ -107,6 +107,7 @@ PyYAML==6.0.1
 requests==2.32.4
 retina-face==0.0.17
 rich==13.7.1
+sentry-sdk==2.43.0
 s3transfer==0.10.1
 scikit-learn==1.5.0
 scipy==1.16.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ imutils==0.5.4
 matplotlib==3.8.4
 celery==5.4.0
 redis==5.2.1
+sentry-sdk[django]==2.43.0
 seaborn==0.13.2
 Pillow==10.3.0
 opencv-python==4.9.0.80


### PR DESCRIPTION
## Summary
- add the sentry-sdk dependency and configure production settings to initialise it from environment variables
- provide a dedicated Sentry helper that enables Django tracing, optional Celery/Redis integrations, and PII scrubbing
- document the new observability variables and operational dashboards required for deployments

## Testing
- pytest --override-ini=addopts= tests/settings/test_production.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912bfd63e1c833085f4b512e26344b5)