### PR TITLE
Add synthetic dataset and reproducibility workflow

### DIFF
--- a/DATA_CARD.md
+++ b/DATA_CARD.md
@@ -77,3 +77,9 @@ Persists a snapshot of a recognition decision made during attendance flows.
 -   The motion-based liveness buffer runs entirely in memory during each recognition attempt; no additional biometric data is stored beyond the existing encrypted training images.
 -   The detector looks for subtle parallax (blinks, head turns, breathing) across a three-to-five-frame window. Extremely static lighting or perfectly stabilized video replays can therefore lower the score or slip through if the DeepFace anti-spoofing model also agrees.
 -   Operators should document any high-risk deployments (e.g., unattended kiosks) and consider pairing this check with hardware sensors or on-device challenge/response if attackers can present high-quality screens within a few centimetres of the camera.
+
+## Sample Dataset for Reproducibility
+
+-   A `sample_data/` directory now ships with the repository. It mirrors the `face_recognition_data/training_dataset/` layout and contains three procedurally generated, non-identifiable JPEG avatars per identity.
+-   The helper script `scripts/reproduce_sample_results.py` temporarily points the evaluation harness at this directory so reviewers can regenerate metrics with `make reproduce` without handling encrypted production photos.
+-   The sample dataset is strictly for demos and smoke tests. Replace it with the encrypted `face_recognition_data/` tree before operating in production so the evaluation pipeline reflects the real enrollment set.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -74,3 +74,13 @@ The application will be available at `http://localhost:8000`.
 ## 5. PWA and Service Worker
 
 The application is a Progressive Web App (PWA) and uses a service worker to cache assets and enable offline functionality. The service worker is served from the root of the application and is controlled by the `progressive_web_app_service_worker` view.
+
+## 6. Reproducibility Smoke Test
+
+Before promoting a new image, run the bundled synthetic evaluation to verify that DeepFace, OpenCV, and the encrypted embedding cache function correctly inside the target environment:
+
+```bash
+docker compose --env-file .env.production run --rm web make reproduce
+```
+
+The command routes the evaluation pipeline through `sample_data/` instead of the encrypted dataset, so no customer photos are required. Review the metrics and artifacts saved under `reports/sample_repro/` to confirm the build is healthy before replacing production assets with the real `face_recognition_data/` volume.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -112,6 +112,8 @@ The project is organized into the following directories:
 -   `recognition`: The Django app that handles face recognition and attendance tracking.
 -   `users`: The Django app that handles user management.
 -   `face_recognition_data`: The directory where the face recognition data is stored.
+-   `sample_data`: A fully synthetic dataset with three demo identities. It mirrors the `face_recognition_data/training_dataset/`
+    layout so you can run the evaluation suite without encrypted production assets.
 
 ## 3. Architecture Overview
 
@@ -144,6 +146,15 @@ Key options:
 - `--threshold-start/stop/step`: Configure the sweep range for FAR/FRR vs threshold plots.
 - `--max-samples`: Quickly smoke-test the pipeline by limiting the number of processed images.
 - `--reports-dir`: Customise where artifacts such as `metrics_summary.json`, `confusion_matrix.png`, and `threshold_sweep.csv` are saved.
+
+For reviewers, the quickest path is to reuse the sample dataset:
+
+```bash
+python scripts/reproduce_sample_results.py  # equivalent to `make reproduce`
+```
+
+The script patches the dataset root in-memory so production deployments remain untouched. Pass `--dataset-root` and `--split-csv`
+to point the same workflow at real encrypted datasets once they are available locally.
 
 ### Threshold Selection
 
@@ -198,6 +209,7 @@ The project includes a comprehensive `Makefile` for common development tasks.
 -   `make evaluate`: Run performance evaluation with metrics
 -   `make ablation`: Run ablation experiments
 -   `make report`: Generate comprehensive reports
+-   `make reproduce`: Evaluate the bundled synthetic dataset and place deterministic artifacts in `reports/sample_repro/`
 
 ## 6. API Reference
 

--- a/Makefile
+++ b/Makefile
@@ -83,15 +83,9 @@ clean:
 	rm -rf htmlcov .coverage .pytest_cache
 	@echo "Cleanup complete."
 
-# Full reproducibility workflow: seed, prepare data, run evaluation, produce artifacts
-reproduce: setup
-@echo "=== Running reproducibility workflow ==="
-@echo "Step 1: Preparing sample dataset and splits..."
-python manage.py prepare_splits
-@echo "Step 2: Running evaluation with fixed seed..."
-python manage.py eval --split-csv reports/splits.csv
-	@echo "Step 3: Generating reports..."
-	python manage.py export_reports
+# Full reproducibility workflow: run the synthetic dataset evaluation
+reproduce:
+	@echo "=== Running sample-data reproducibility workflow ==="
+	python scripts/reproduce_sample_results.py
 	@echo "=== Reproducibility workflow complete ==="
-	@echo "Artifacts available in reports/ directory."
-	@echo "You can now run the server with 'make run'."
+	@echo "Artifacts available in reports/sample_repro/."

--- a/README.md
+++ b/README.md
@@ -109,6 +109,31 @@ For more detailed information, please refer to the full documentation:
 - **[Deployment Guide](docs/deployment-guide.md)**: Step-by-step instructions for building the Docker image, configuring Compose services, managing environment variables, and hardening production deployments.
 - **[Fairness & Limitations](docs/FAIRNESS_AND_LIMITATIONS.md)**: Methodology, findings, and follow-up actions for the fairness and robustness audit plus guidance on how to rerun it locally.
 
+## Reproducibility
+
+The repository now ships with a tiny, synthetic dataset under
+`sample_data/face_recognition_data/training_dataset/` so reviewers can exercise
+the full recognition pipeline without requesting encrypted production assets.
+Run the following command after installing dependencies to regenerate the
+metrics referenced in the documentation:
+
+```bash
+make reproduce
+```
+
+The target launches `scripts/reproduce_sample_results.py`, which points the
+evaluation harness at the bundled dataset, seeds the random number generators,
+and saves artifacts (metrics JSON, confusion matrix, per-sample CSV) to
+`reports/sample_repro/`. You can supply your own dataset or split CSV by
+invoking the script directly:
+
+```bash
+python scripts/reproduce_sample_results.py --dataset-root /path/to/your/data --split-csv custom.csv
+```
+
+The script overwrites neither `face_recognition_data/` nor production caches; it
+patches the dataset root in-memory so regular deployments remain unchanged.
+
 ## Limitations & Responsible Use
 
 Face biometrics introduce safety and ethical constraints that require explicit monitoring. Run `python manage.py fairness_audit --split-csv reports/splits.csv --reports-dir reports/fairness` whenever the dataset changes to capture per-role, per-site, per-source, and per-lighting metrics. The resulting tables in `reports/fairness/summary.md` highlight buckets where the False Acceptance Rate (FAR) or False Rejection Rate (FRR) deviates from the global average. Review the [Fairness & Limitations](docs/FAIRNESS_AND_LIMITATIONS.md) report alongside the [DATA_CARD.md](DATA_CARD.md) before rolling out models to new locations or populations.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -87,6 +87,8 @@ The command reuses the live recognition engine to process the encrypted image da
 
 Use these reports to fine-tune thresholds before rolling changes into production or to document the system's performance for compliance reviews.
 
+> **Tip for reviewers:** The repository includes a `sample_data/` directory with three synthetic identities so you can rehearse the full workflow without using production assets. Running `make reproduce` will point the evaluation pipeline at that demo dataset and deposit artifacts under `reports/sample_repro/`.
+
 ## 6. Responsible Use & Limitations
 
 - **Fairness audit:** Run `python manage.py fairness_audit --split-csv reports/splits.csv --reports-dir reports/fairness` after major enrollment batches or hardware changes. The command captures recognition accuracy, precision/recall, and FAR/FRR for different user-role buckets, commonly used sites, capture sources, and coarse lighting conditions. Review the generated `reports/fairness/summary.md` so you can identify groups that require additional training photos or new lighting guidance.

--- a/sample_data/README.md
+++ b/sample_data/README.md
@@ -1,0 +1,48 @@
+# Sample Face Recognition Dataset
+
+This directory contains a **fully synthetic** dataset that mirrors the on-disk
+layout expected by the face-recognition pipeline:
+
+```
+sample_data/
+  face_recognition_data/
+    training_dataset/
+      user_001/
+      user_002/
+      user_003/
+```
+
+Each user folder stores three 256×256 JPEG frames that were procedurally
+generated with Pillow. The shapes and colours intentionally resemble stylised
+avatars instead of real faces, so the repository never ships personal data.
+
+The dataset is distributed purely for **testing and documentation** purposes.
+It is safe to check into version control and can be regenerated with the helper
+snippet below:
+
+```python
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+base = Path("sample_data/face_recognition_data/training_dataset")
+users = {
+    "user_001": ("Cyan", (0, 160, 200)),
+    "user_002": ("Magenta", (180, 60, 160)),
+    "user_003": ("Amber", (210, 150, 60)),
+}
+
+for username, (_, color) in users.items():
+    folder = base / username
+    folder.mkdir(parents=True, exist_ok=True)
+    for idx in range(3):
+        image = Image.new("RGB", (256, 256), (15, 15, 20))
+        draw = ImageDraw.Draw(image)
+        draw.ellipse((68, 50, 188, 170), fill=color)
+        draw.rectangle((70, 160, 190, 220), fill=tuple(min(c + 30, 255) for c in color))
+        draw.text((40, 20), f"{username}\nFrame {idx + 1}", fill=(230, 230, 230))
+        image.save(folder / f"{username}_frame_{idx + 1:02d}.jpg", format="JPEG", quality=95)
+```
+
+Feel free to extend this directory locally with additional synthetic subjects.
+The reproducibility workflow automatically points the evaluation engine at this
+folder, so production deployments remain unaffected.

--- a/sample_data/reports/sample_splits.csv
+++ b/sample_data/reports/sample_splits.csv
@@ -1,0 +1,10 @@
+index,split,person,image_path
+0,test,user_001,user_001/user_001_frame_01.jpg
+1,test,user_001,user_001/user_001_frame_02.jpg
+2,test,user_001,user_001/user_001_frame_03.jpg
+3,test,user_002,user_002/user_002_frame_01.jpg
+4,test,user_002,user_002/user_002_frame_02.jpg
+5,test,user_002,user_002/user_002_frame_03.jpg
+6,test,user_003,user_003/user_003_frame_01.jpg
+7,test,user_003,user_003/user_003_frame_02.jpg
+8,test,user_003,user_003/user_003_frame_03.jpg

--- a/scripts/reproduce_sample_results.py
+++ b/scripts/reproduce_sample_results.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Reproduce face-recognition metrics using the bundled synthetic dataset."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _default_paths() -> tuple[Path, Path, Path]:
+    base = _project_root()
+    dataset_root = base / "sample_data" / "face_recognition_data" / "training_dataset"
+    split_csv = base / "sample_data" / "reports" / "sample_splits.csv"
+    reports_dir = base / "reports" / "sample_repro"
+    return dataset_root, split_csv, reports_dir
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    dataset_root, split_csv, reports_dir = _default_paths()
+    parser = argparse.ArgumentParser(
+        description="Run the evaluation pipeline against the synthetic sample dataset.",
+    )
+    parser.add_argument(
+        "--dataset-root",
+        type=Path,
+        default=dataset_root,
+        help="Root directory that contains per-user folders with JPEG frames.",
+    )
+    parser.add_argument(
+        "--split-csv",
+        type=Path,
+        default=split_csv,
+        help="Optional CSV describing the evaluation split (defaults to sample_splits.csv).",
+    )
+    parser.add_argument(
+        "--reports-dir",
+        type=Path,
+        default=reports_dir,
+        help="Directory where the evaluation artifacts will be stored.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed forwarded to the evaluation helpers.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="Optional distance threshold override.",
+    )
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="Limit the number of evaluation samples (handy for smoke tests).",
+    )
+    return parser.parse_args(argv)
+
+
+def _ensure_django_ready() -> None:
+    project_root = _project_root()
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "attendance_system_facial_recognition.settings"
+    )
+    import django
+
+    django.setup()
+
+
+def _patch_dataset_root(dataset_root: Path) -> None:
+    from recognition import views as recognition_views
+
+    recognition_views.DATA_ROOT = dataset_root.parent
+    recognition_views.TRAINING_DATASET_ROOT = dataset_root
+    recognition_views._dataset_embedding_cache = recognition_views.DatasetEmbeddingCache(
+        recognition_views.TRAINING_DATASET_ROOT,
+        recognition_views.DATA_ROOT,
+    )
+
+
+def _validate_dataset(dataset_root: Path) -> int:
+    if not dataset_root.exists():
+        raise FileNotFoundError(
+            f"Dataset root {dataset_root} does not exist. Run from the repository root or "
+            "provide --dataset-root."
+        )
+
+    jpeg_count = len(list(dataset_root.glob("*/*.jpg")))
+    if jpeg_count == 0:
+        raise RuntimeError(
+            f"Dataset root {dataset_root} does not contain any .jpg files. "
+            "Verify that sample_data is intact."
+        )
+    return jpeg_count
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    dataset_root = args.dataset_root.resolve()
+    split_csv = args.split_csv.resolve()
+    reports_dir = args.reports_dir.resolve()
+
+    try:
+        sample_count = _validate_dataset(dataset_root)
+    except Exception as exc:  # pragma: no cover - CLI helper
+        print(f"[reproduce] {exc}", file=sys.stderr)
+        return 1
+
+    if split_csv.exists():
+        split_path: Optional[Path] = split_csv
+    else:
+        split_path = None
+        print(
+            f"[reproduce] Split CSV {split_csv} not found. Falling back to scanning the dataset root.",
+            file=sys.stderr,
+        )
+
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    _ensure_django_ready()
+    _patch_dataset_root(dataset_root)
+
+    from src.common.seeding import set_global_seed
+    from src.evaluation.face_recognition_eval import EvaluationConfig, run_face_recognition_evaluation
+
+    set_global_seed(args.seed)
+
+    print("=== Attendance sample reproducibility run ===")
+    print(f"Dataset root : {dataset_root}")
+    print(f"Split CSV    : {split_path or 'scan entire dataset'}")
+    print(f"Reports dir  : {reports_dir}")
+    print(f"Samples      : {sample_count}")
+
+    config = EvaluationConfig(
+        reports_dir=reports_dir,
+        test_split_csv=split_path,
+        dataset_root=dataset_root,
+        threshold=args.threshold,
+        limit_samples=args.max_samples,
+    )
+
+    summary = run_face_recognition_evaluation(config)
+
+    print("\nMetrics (macro averages unless noted):")
+    for key in ("accuracy", "precision", "recall", "f1", "far", "frr"):
+        value = summary.metrics.get(key)
+        if value is None:
+            continue
+        print(f"  - {key.title():<9}: {value:.4f}")
+
+    print("\nArtifacts:")
+    for label, path in summary.artifact_paths.items():
+        print(f"  - {label:>12}: {path}")
+
+    print("\nDone. Inspect the artifacts above for the deterministic outputs.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a fully synthetic `sample_data/` tree so reviewers can exercise the face-recognition pipeline without encrypted assets
- introduce `scripts/reproduce_sample_results.py` plus a simplified `make reproduce` target that runs the evaluation against the sample dataset and writes artifacts to `reports/sample_repro/`
- document the new workflow across the README, DATA_CARD, USER_GUIDE, DEVELOPER_GUIDE, and DEPLOYMENT guide so contributors know when to use the bundled data versus real datasets

## Testing
- `python scripts/reproduce_sample_results.py --max-samples 1` *(fails: ImportError: libGL.so.1 missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bfebd6844833089e5310956952c2a)