### PR TITLE
Fix ML optimization, thread safety, and Bandit warnings

### DIFF
--- a/recognition/test_metrics.py
+++ b/recognition/test_metrics.py
@@ -19,19 +19,19 @@ class MetricsTest(TestCase):
 
     def setUp(self):
         """Create synthetic evaluation data."""
-        np.random.seed(42)
+        rng = np.random.default_rng(42)
         n = 100
 
         # Create binary labels
         self.y_true = np.array([1] * 50 + [0] * 50)
 
         # Create scores (genuine pairs have higher scores)
-        scores_genuine = np.random.beta(8, 2, 50)
-        scores_impostor = np.random.beta(2, 8, 50)
+        scores_genuine = rng.beta(8, 2, 50)
+        scores_impostor = rng.beta(2, 8, 50)
         self.y_scores = np.concatenate([scores_genuine, scores_impostor])
 
         # Shuffle
-        shuffle_idx = np.random.permutation(n)
+        shuffle_idx = rng.permutation(n)
         self.y_true = self.y_true[shuffle_idx]
         self.y_scores = self.y_scores[shuffle_idx]
 

--- a/src/evaluation/fairness.py
+++ b/src/evaluation/fairness.py
@@ -261,7 +261,9 @@ def annotate_samples(samples: Sequence[SampleEvaluation]) -> List[AnnotatedSampl
                     lighting_bucket="unknown",
                 ),
             )
-        base_context = context_map[username] if username in context_map else default_contexts[username]
+        base_context = (
+            context_map[username] if username in context_map else default_contexts[username]
+        )
         context = replace(base_context)
         context.lighting_bucket = estimate_lighting_bucket(sample.image_path)
         annotated.append(AnnotatedSample(sample=sample, context=context))

--- a/src/evaluation/fairness.py
+++ b/src/evaluation/fairness.py
@@ -261,7 +261,7 @@ def annotate_samples(samples: Sequence[SampleEvaluation]) -> List[AnnotatedSampl
                     lighting_bucket="unknown",
                 ),
             )
-        base_context = context_map.get(username, default_contexts[username])
+        base_context = context_map[username] if username in context_map else default_contexts[username]
         context = replace(base_context)
         context.lighting_bucket = estimate_lighting_bucket(sample.image_path)
         annotated.append(AnnotatedSample(sample=sample, context=context))

--- a/tests/recognition/test_face_recognition_workflow.py
+++ b/tests/recognition/test_face_recognition_workflow.py
@@ -63,7 +63,7 @@ class TestFaceRecognitionWorkflow:
             lambda *args, **kwargs: expected_embedding,
         )
 
-        encoding = tasks.compute_face_encoding(Path("/tmp/fake-image.jpg"))
+        encoding = tasks.compute_face_encoding(Path("fake-image.jpg"))
 
         assert isinstance(encoding, np.ndarray)
         assert encoding.dtype == np.float64

--- a/tests/recognition/test_liveness.py
+++ b/tests/recognition/test_liveness.py
@@ -58,7 +58,7 @@ def test_evaluate_match_blocks_spoof(monkeypatch):
     frame = np.zeros((10, 10, 3), dtype=np.uint8)
     match = pd.Series(
         {
-            "identity": "/tmp/train/alice/1.jpg",
+            "identity": "train/alice/1.jpg",
             "distance": 0.2,
             "source_x": 5,
             "source_y": 6,
@@ -84,7 +84,7 @@ def test_evaluate_match_accepts_live_face(monkeypatch):
     frame = np.zeros((10, 10, 3), dtype=np.uint8)
     match = pd.Series(
         {
-            "identity": "/tmp/train/bob/1.jpg",
+            "identity": "train/bob/1.jpg",
             "distance": 0.1,
             "source_x": 2,
             "source_y": 3,


### PR DESCRIPTION
This PR addresses several optimization and linting issues:
1. Replaced global `np.random.seed` mutations with localized `np.random.default_rng` to ensure thread-safety and reproducibility in tests.
2. Fixed eager evaluation in `dict.get` within `src/evaluation/fairness.py` to prevent potential `KeyError`s during fallback execution.
3. Updated test files to use relative paths instead of hardcoded `/tmp/` paths, fixing Bandit B108 warnings.

---
*PR created automatically by Jules for task [15284230727631148984](https://jules.google.com/task/15284230727631148984) started by @saint2706*