### PR TITLE
Explicitly define serviceAccountName in statefulsets

### DIFF
--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: postgres
         app.kubernetes.io/component: database
     spec:
+      serviceAccountName: default
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: redis
         app.kubernetes.io/component: cache
     spec:
+      serviceAccountName: default
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
- Added explicit `serviceAccountName: default` to Postgres and Redis statefulsets to conform to best practices.
- Validated YAML with kubeconform and yamllint.
- Tested Kustomize overlays.

---
*PR created automatically by Jules for task [2642910721746236721](https://jules.google.com/task/2642910721746236721) started by @saint2706*