### PR TITLE
🎨 Picasso: [UX improvement] Add loading feedback for actions

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -36,3 +36,4 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 - Added explicit `title` tooltips to the main call-to-action buttons in `Home.tsx` ("Mark Time-In", "Mark Time-Out", "Dashboard Login") to provide additional context.
 - Added `title` tooltips to the "Return Home", "Mark Another", "Try Again", and "Retry" action buttons in the `MarkAttendance.tsx` page to improve intent clarity.
 - Added descriptive `title` tooltips to the "Try Again" error state button and the "Register Employee" empty state link in the `Dashboard.tsx` view for better usability.
+* When adding a loading indicator, be sure to use `lucide-react`'s `Loader2` and make sure it is imported properly. It's common to miss the import when inserting the element. Always check lint and build to verify.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,7 +13,8 @@ import {
     UserCheck,
     Activity,
     AlertTriangle,
-    RefreshCw
+    RefreshCw,
+    Loader2
 } from 'lucide-react';
 import './Dashboard.css';
 
@@ -88,9 +89,13 @@ export const Dashboard = () => {
                         <AlertTriangle size={48} className="mx-auto text-warning mb-sm" aria-hidden="true" />
                         <h3 className="text-lg font-semibold mb-xs">Failed to load statistics</h3>
                         <p className="text-muted mb-md">We couldn't retrieve the latest dashboard data.</p>
-                        <button onClick={() => fetchStats()} className="btn btn-secondary" title="Retry loading statistics">
-                            <RefreshCw size={18} aria-hidden="true" />
-                            Try Again
+                        <button onClick={() => fetchStats()} className="btn btn-secondary" title="Retry loading statistics" disabled={isLoadingStats}>
+                            {isLoadingStats ? (
+                                <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                            ) : (
+                                <RefreshCw size={18} aria-hidden="true" />
+                            )}
+                            {isLoadingStats ? 'Retrying...' : 'Try Again'}
                         </button>
                     </div>
                 ) : !isLoadingStats && stats.totalEmployees === 0 ? (

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -240,9 +240,13 @@ export const MarkAttendance = () => {
                         <div className="camera-error" role="alert" aria-live="assertive">
                             <CameraOff size={48} aria-hidden="true" />
                             <p>{error}</p>
-                            <button onClick={startCamera} className="btn btn-primary" title="Retry connecting to camera">
-                                <RefreshCw size={18} aria-hidden="true" />
-                                Retry
+                            <button onClick={startCamera} className="btn btn-primary" title="Retry connecting to camera" disabled={isInitializing}>
+                                {isInitializing ? (
+                                    <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                                ) : (
+                                    <RefreshCw size={18} aria-hidden="true" />
+                                )}
+                                {isInitializing ? 'Retrying...' : 'Retry'}
                             </button>
                         </div>
                     ) : (


### PR DESCRIPTION
This PR addresses the "Missing feedback for actions" from the Picasso persona checklist.

- Adds a loading spinner (`Loader2` from `lucide-react`) and disables the "Try Again" button in `Dashboard.tsx` when `isLoadingStats` is true.
- Adds a loading spinner (`Loader2` from `lucide-react`) and disables the "Retry" button in `MarkAttendance.tsx` when `isInitializing` is true.
- Updated `.jules/picasso.md` with learnings on ensuring correct imports for newly added icons.

### Before
Buttons could be clicked repeatedly while the async action was already running, and there was no visual feedback that the action was in progress.

### After
Buttons are disabled, text changes to "Retrying...", and a spinner is shown while the action runs.

---
*PR created automatically by Jules for task [3415007281717964252](https://jules.google.com/task/3415007281717964252) started by @saint2706*