### PR TITLE
Secure ML model loading by disallowing pickle in np.load

### DIFF
--- a/.jules/aiml_log.md
+++ b/.jules/aiml_log.md
@@ -1,0 +1,1 @@
+We removed allow_pickle=True to prevent security vulnerabilities and fixed tests calling obsolete methods

--- a/recognition/tests.py
+++ b/recognition/tests.py
@@ -50,11 +50,11 @@ class DeepFaceAttendanceTest(TestCase):
     def test_default_deepface_configuration(self):
         """Defaults should mirror the legacy DeepFace configuration."""
 
-        self.assertEqual(views._get_face_recognition_model(), "Facenet")
-        self.assertEqual(views._get_face_detection_backend(), "ssd")
-        self.assertEqual(views._get_deepface_distance_metric(), "euclidean_l2")
-        self.assertFalse(views._should_enforce_detection())
-        self.assertTrue(views._is_liveness_enabled())
+        self.assertEqual(views.get_face_recognition_model(), "Facenet")
+        self.assertEqual(views.get_face_detection_backend(), "ssd")
+        self.assertEqual(views.get_deepface_distance_metric(), "euclidean_l2")
+        self.assertFalse(views.should_enforce_detection())
+        self.assertTrue(views.is_liveness_enabled())
 
     def test_deepface_configuration_overrides(self):
         """Environment or settings overrides should cascade through helpers."""
@@ -69,11 +69,11 @@ class DeepFaceAttendanceTest(TestCase):
         }
 
         with self.settings(DEEPFACE_OPTIMIZATIONS=overrides):
-            self.assertEqual(views._get_face_recognition_model(), "ArcFace")
-            self.assertEqual(views._get_face_detection_backend(), "retinaface")
-            self.assertEqual(views._get_deepface_distance_metric(), "cosine")
-            self.assertTrue(views._should_enforce_detection())
-            self.assertFalse(views._is_liveness_enabled())
+            self.assertEqual(views.get_face_recognition_model(), "ArcFace")
+            self.assertEqual(views.get_face_detection_backend(), "retinaface")
+            self.assertEqual(views.get_deepface_distance_metric(), "cosine")
+            self.assertTrue(views.should_enforce_detection())
+            self.assertFalse(views.is_liveness_enabled())
 
     def _setup_mocks(self, mock_manager_factory, mock_cv2, frames=None):
         """Configure common mocks for video processing to isolate view logic."""

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -3600,7 +3600,7 @@ def get_loaded_model():
 
             _loaded_classes = np.array(json.loads(decrypted_classes.decode("utf-8")))
         else:
-            _loaded_classes = np.load(io.BytesIO(decrypted_classes), allow_pickle=True)
+            _loaded_classes = np.load(io.BytesIO(decrypted_classes), allow_pickle=False)
         _loaded_model_mtime = current_mtime
     except Exception as exc:
         logger.warning("Failed to load cached ML model: %s", exc)

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -3790,7 +3790,7 @@ def get_loaded_model():
 
             _loaded_classes = np.array(json.loads(decrypted_classes.decode("utf-8")))
         else:
-            _loaded_classes = np.load(io.BytesIO(decrypted_classes), allow_pickle=True)
+            _loaded_classes = np.load(io.BytesIO(decrypted_classes), allow_pickle=False)
         _loaded_model_mtime = current_mtime
     except Exception as exc:
         logger.warning("Failed to load cached ML model: %s", exc)


### PR DESCRIPTION
Removed `allow_pickle=True` to address AIML security warnings regarding insecure deserialization. Also updated unit tests to use the new public API methods for DeepFace configuration, allowing the test suite to pass again.

---
*PR created automatically by Jules for task [13760202444517058644](https://jules.google.com/task/13760202444517058644) started by @saint2706*