### PR TITLE
📚 Docs: Add missing frontend JSDoc/TSDoc comments

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -28,3 +28,4 @@
 - Fixed broken bug report and feature request template links in `CONTRIBUTING.md`.
 - Added missing TSDoc to `LoginCredentialsSchema` and `RegisterDataSchema` in `frontend/src/api/auth.ts`.
 - **2025-03-08 (Session 3)**: Fixed `markdown-link-check` configuration by correcting regex escapes for `127.0.0.1` and `github.com` and accurately targeting `issues/new/choose` endpoint. Verified all docs and lint tasks pass completely clean.
+- **2025-03-08 (Session 4)**: Audited codebase for missing documentation. Added missing TSDoc/JSDoc block to `ActionCard` component in `frontend/src/components/ActionCard.tsx` and to the queryClient initialization in `frontend/src/main.tsx`. Verified build and lint steps passed successfully, updating `CHANGELOG.md` to reflect these changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog was initially reconstructed from the git history on 2025-11-29, a
 
 ### Added (Unreleased)
 
+- Added missing TSDoc/JSDoc comments to `ActionCard` in `frontend/src/components/ActionCard.tsx` and `queryClient` in `frontend/src/main.tsx`
 - Added missing TSDoc comments to `LoginCredentialsSchema` and `RegisterDataSchema` in the frontend API
 - Advanced admin commands and documentation updates (`9d1f2fb`)
 - Domain adaptation, sample quality, and group threshold support (`ad9e8bf`)

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -9,6 +9,18 @@ interface ActionCardProps {
     description: string;
 }
 
+/**
+ * A reusable card component for navigation actions.
+ * Displays an icon, heading, and description within a clickable card.
+ *
+ * @param {ActionCardProps} props - The properties for the ActionCard component.
+ * @param {string} props.to - The destination URL for the link.
+ * @param {string} props.title - The title attribute for the link.
+ * @param {React.ElementType} props.icon - The icon component to display.
+ * @param {string} props.heading - The main heading text.
+ * @param {string} props.description - The descriptive text below the heading.
+ * @returns {JSX.Element} The rendered ActionCard component.
+ */
 export const ActionCard = React.memo(({ to, title, icon: Icon, heading, description }: ActionCardProps) => {
     return (
         <Link to={to} className="action-card card card-elevated" title={title}>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,10 @@ import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App.tsx'
 
+/**
+ * The main entry point for the React application.
+ * Initializes the query client and renders the root App component.
+ */
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Addressed missing JSDoc/TSDoc comments in the frontend `ActionCard` component and `main.tsx` initialization code. This improves code clarity and synchronization with the actual implementation, adhering to the Docs persona guidelines. Build and lint checks were verified to pass.

---
*PR created automatically by Jules for task [13730108310792043226](https://jules.google.com/task/13730108310792043226) started by @saint2706*