### PR TITLE
🔌 API: Fixed DRF content_type and un-mocked exceptions

### DIFF
--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -308,7 +308,7 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
         )
 
         if match_result is None:
-            return Response(
+            response = Response(
                 {
                     "type": "about:blank",
                     "title": "Match Failed",
@@ -318,8 +318,9 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
                     "recognition": {"detected": True, "matched": False},
                 },
                 status=status.HTTP_200_OK,
-                content_type="application/problem+json",
             )
+            response.content_type = "application/problem+json"
+            return response
 
         matched_username, distance, _ = match_result
 

--- a/tests/recognition/test_api_exceptions.py
+++ b/tests/recognition/test_api_exceptions.py
@@ -110,66 +110,30 @@ class TestCustomExceptionHandler:
 
     def test_api_exception_fallback(self):
         class WeirdException(exceptions.APIException):
-            pass
+            status_code = 500
+            default_detail = "Some raw string"
 
         exc = WeirdException()
-        exc.detail = None  # Mess with it so it has no real detail
+        # Override the generated ErrorDetail object directly to bypass dict/list checks
+        exc.detail = "Some raw string"
 
-        # We need to simulate the response that exception_handler would create
-        # But we actually want DRF to create it
+        response = custom_exception_handler(exc, self.context)
 
-        # If we provide a detail=None, DRF usually sets detail=default_detail
-
-        # Let's mock response.data to trigger the `else` case in detail extraction
-        # We'll just patch exception_handler to return a mock response
-        from unittest import mock
-
-        from rest_framework.response import Response
-
-        with mock.patch("recognition.api.exceptions.exception_handler") as mock_handler:
-            mock_resp = mock.MagicMock(spec=Response)
-            mock_resp.status_code = 500
-            # A data type that is not a dict or list to hit the else clause `detail = str(exc)`
-            mock_resp.data = "Some raw string"
-            mock_handler.return_value = mock_resp
-
-            exc_with_default = WeirdException()
-            response = custom_exception_handler(exc_with_default, self.context)
-
-            assert response is not None
-            assert response.data["detail"] == "Some raw string"
+        assert response is not None
+        assert response.data["detail"] == "Some raw string"
 
     def test_api_exception_fallback_with_default_detail(self):
-        class WeirdException(exceptions.APIException):
+        class EmptyStrWeirdException(exceptions.APIException):
+            status_code = 500
             default_detail = "This is a default detail."
 
-        exc = WeirdException()
-        exc.detail = None  # Mess with it so it has no real detail
+            def __str__(self):
+                return ""
 
-        from unittest import mock
+        exc_empty = EmptyStrWeirdException()
+        exc_empty.detail = ""
 
-        from rest_framework.response import Response
+        response = custom_exception_handler(exc_empty, self.context)
 
-        with mock.patch("recognition.api.exceptions.exception_handler") as mock_handler:
-            mock_resp = mock.MagicMock(spec=Response)
-            mock_resp.status_code = 500
-            # Empty string for detail to hit the 'not detail' check
-            mock_resp.data = ""
-            mock_handler.return_value = mock_resp
-
-            # To test default_detail properly, we construct the object directly and patch str so it looks empty
-            # But the previous mock wasn't working correctly because DRF's exception_handler uses isinstance, and mock breaks it.
-            # Instead, we just pass an object that natively stringifies to empty string!
-            class EmptyStrWeirdException(exceptions.APIException):
-                default_detail = "This is a default detail."
-
-                def __str__(self):
-                    return ""
-
-            exc_empty = EmptyStrWeirdException()
-            exc_empty.detail = None
-
-            response = custom_exception_handler(exc_empty, self.context)
-
-            assert response is not None
-            assert response.data["detail"] == "This is a default detail."
+        assert response is not None
+        assert response.data["detail"] == "This is a default detail."


### PR DESCRIPTION
- `recognition/api/views.py`: Assigned `content_type` directly to instantiated `Response` object instead of using kwargs. This avoids false-positive type/lint errors and ensures custom `application/problem+json` overrides any default negotiation.
- `tests/recognition/test_api_exceptions.py`: Refactored test classes to use explicitly constructed APIExceptions rather than `mock.patch`, addressing `isinstance` check failures and promoting better test fidelity as outlined in memory guidelines.

---
*PR created automatically by Jules for task [730291782399782315](https://jules.google.com/task/730291782399782315) started by @saint2706*