### PR TITLE
🧘 Buddha: [PERF] Eager load Home route for better LCP

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -4,6 +4,7 @@
 - [PERF] Verified Hero image optimization in Home.tsx.
 - [SEO] Verified JSON-LD schema.
 ## SEO/GEO Improvements
+- `[PERF]`: Replaced lazy loading with eager loading for the `Home` route in `frontend/src/App.tsx` to significantly improve Largest Contentful Paint (LCP) by preventing the hero section from being network-delayed.
 - `[GEO] [SEO]`: Moved static JSON-LD from `frontend/index.html` to dynamic React component using `dangerouslySetInnerHTML` in `frontend/src/pages/Home.tsx`.
 - `[GEO] [SEO]`: Implemented JSON-LD WebPage schema in Dashboard, Login, and MarkAttendance pages using `dangerouslySetInnerHTML`.
 - `[PERF]`: Removed unused `icon-512.png` image preload tag from `frontend/index.html` to fix Lighthouse "Remove unused preloads" and improve LCP for actual critical resources.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { Navbar } from './components/layout/Navbar';
 import './index.css';
 
-const Home = React.lazy(() => import('./pages/Home').then(module => ({ default: module.Home })));
+import { Home } from './pages/Home';
 const Login = React.lazy(() => import('./pages/Login').then(module => ({ default: module.Login })));
 const Dashboard = React.lazy(() => import('./pages/Dashboard').then(module => ({ default: module.Dashboard })));
 const MarkAttendance = React.lazy(() => import('./pages/MarkAttendance').then(module => ({ default: module.MarkAttendance })));


### PR DESCRIPTION
Replaced `React.lazy` with eager importing for the `Home` route in `App.tsx` to significantly improve Largest Contentful Paint (LCP) for users landing on the home page. Logged the progress to the Buddha Scroll.

---
*PR created automatically by Jules for task [9714258521858425983](https://jules.google.com/task/9714258521858425983) started by @saint2706*