### PR TITLE
⚙️ CI/CD: Optimize yamllint caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
 
       - name: Lint YAML files
         run: |
-          pip install yamllint==1.35.1
           yamllint .github/workflows/
 
   # Fast tests job - runs on every push and PR

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ psycopg2-binary==2.9.11
 pre-commit==4.0.1
 playwright==1.58.0
 pytest-playwright==0.7.2
+yamllint==1.35.1


### PR DESCRIPTION
Moved `yamllint` into `requirements-dev.txt` to allow the GitHub Actions `setup-python` cache to store the dependency, optimizing pipeline speed and eliminating redundant network installations. Cleaned up the workflow file accordingly and verified using `actionlint` and the test suite.

---
*PR created automatically by Jules for task [12129625943673186226](https://jules.google.com/task/12129625943673186226) started by @saint2706*