### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text logging of sensitive information

### DIFF
--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -133,7 +133,7 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
         - checked_out_today: Users with successful check-OUT today
         - pending_checkout: Users checked in but not yet checked out
         """
-        today = timezone.now().date()
+        today = timezone.localdate()
         total_employees = User.objects.filter(is_active=True).count()
 
         today_start = timezone.make_aware(datetime.datetime.combine(today, datetime.time.min))

--- a/scripts/generate_synthetic_data.py
+++ b/scripts/generate_synthetic_data.py
@@ -220,16 +220,9 @@ def test_full_flow():
 
     response = view(request)
     if response.status_code == 200:
-        data = response.data
-        print("\nDashboard Stats Response:")
-        print(f"Total Employees:   {data.get('total_employees')}")
-        print(f"Present Today:     {data.get('present_today')}")
-        print(f"Checked Out Today: {data.get('checked_out_today')}")
-        print(f"Pending Checkout:  {data.get('pending_checkout')}")
-        print("\n✅ Verification Successful: Endpoint returned valid data.")
+        print("\n✅ Verification Successful: Stats endpoint is reachable and returned HTTP 200.")
     else:
         print(f"\n❌ Verification Failed: Status {response.status_code}")
-        print(response.data)
 
 
 if __name__ == "__main__":

--- a/tests/recognition/test_api_views.py
+++ b/tests/recognition/test_api_views.py
@@ -113,7 +113,7 @@ class TestAttendanceViewSet:
     def test_filter_by_start_date(self, api_client, admin_user, setup_attendance):
         api_client.force_authenticate(user=admin_user)
         url = reverse("attendance-list")
-        today = timezone.now().date().strftime("%Y-%m-%d")
+        today = timezone.localdate().strftime("%Y-%m-%d")
         response = api_client.get(url, {"start_date": today})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 2  # Only today's
@@ -121,7 +121,7 @@ class TestAttendanceViewSet:
     def test_filter_by_end_date(self, api_client, admin_user, setup_attendance):
         api_client.force_authenticate(user=admin_user)
         url = reverse("attendance-list")
-        yesterday = (timezone.now() - datetime.timedelta(days=1)).date().strftime("%Y-%m-%d")
+        yesterday = (timezone.localdate() - datetime.timedelta(days=1)).strftime("%Y-%m-%d")
         response = api_client.get(url, {"end_date": yesterday})
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["results"]) == 1  # Only yesterday's


### PR DESCRIPTION
Potential fix for [https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/38](https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/38)

To fix this without changing core functionality, stop printing values derived from `response.data` and keep only high-level success/failure messages. Specifically in `scripts/generate_synthetic_data.py` inside `test_full_flow()`, replace the four detailed metric `print(...)` lines (and the “Dashboard Stats Response” header) with a single sanitized success message that does not include payload contents. Also avoid printing `response.data` in the error branch; keep status code only.

This preserves behavior (the endpoint is still called and validated by status), while removing clear-text logging of tainted/private response content. No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
