### PR TITLE
Potential fix for code scanning alert no. 37: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -389,7 +389,15 @@ class FaceRecognitionAPI(View):
                         valid_key = True
 
             if valid_key:
-                masked_key = hashlib.sha256(api_key.encode()).hexdigest()
+                mask_salt = (
+                    getattr(settings, "RECOGNITION_API_KEY_MASK_SALT", "") or settings.SECRET_KEY
+                ).encode("utf-8")
+                masked_key = hashlib.pbkdf2_hmac(
+                    "sha256",
+                    api_key.encode("utf-8"),
+                    mask_salt,
+                    600000,
+                ).hex()
                 request.face_api_principal = f"api-key:{masked_key}"
                 return True, request.face_api_principal, None
             return False, None, "Invalid API key provided."


### PR DESCRIPTION
Potential fix for [https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/37](https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/37)

Use a password-hard key derivation function instead of raw SHA-256 when deriving a display/log mask from an API key. The best low-impact fix here is `hashlib.pbkdf2_hmac` with SHA-256, a high iteration count, and a stable application salt (from settings) so the masked value remains deterministic across requests.

In `recognition/views_legacy.py`, update line 392 region inside `_authenticate_request`:
- Replace `hashlib.sha256(api_key.encode()).hexdigest()` with PBKDF2-HMAC derivation.
- Read salt from a setting such as `RECOGNITION_API_KEY_MASK_SALT` (fallback to `SECRET_KEY` to avoid breakage).
- Encode salt to bytes and derive a hex string with `.hex()`.

No new external dependency is required; this uses Python stdlib `hashlib` already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
