### PR TITLE
Potential fix for code scanning alert no. 36: Clear-text logging of sensitive information

### DIFF
--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import hashlib
 import io
 import logging
 import time
@@ -67,6 +68,13 @@ def _ensure_directory(path: Path) -> None:
     """Create parent directories for the provided path."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def _redact_employee_id_for_log(employee_id: str) -> str:
+    """Return a stable, non-reversible token for safe employee-id logging."""
+
+    digest = hashlib.sha256(employee_id.encode("utf-8")).hexdigest()[:12]
+    return f"emp:{digest}"
 
 
 def load_existing_encodings(employee_id: str) -> np.ndarray:
@@ -467,8 +475,13 @@ def train_recognition_model(self, initiated_by: str | None = None) -> dict[str, 
 def incremental_face_training(self, employee_id: str, new_images: Sequence[str]) -> dict[str, Any]:
     """Incrementally update stored encodings and classifier for the employee."""
 
+    redacted_employee = _redact_employee_id_for_log(employee_id)
+
     if not new_images:
-        logger.debug("No new images supplied for %s; skipping incremental training.", employee_id)
+        logger.debug(
+            "No new images supplied for %s; skipping incremental training.",
+            redacted_employee,
+        )
         return {
             "employee_id": employee_id,
             "images_provided": 0,
@@ -477,7 +490,7 @@ def incremental_face_training(self, employee_id: str, new_images: Sequence[str])
 
     logger.info(
         "Starting incremental training for %s with %d images.",
-        employee_id,
+        redacted_employee,
         len(new_images),
     )
 
@@ -565,11 +578,11 @@ def incremental_face_training(self, employee_id: str, new_images: Sequence[str])
         logger.debug("FAISS index updated with %d embeddings.", faiss_index.size)
 
     except Exception as exc:  # pragma: no cover - defensive programming
-        logger.error("Incremental training failed for %s: %s", employee_id, exc)
+        logger.error("Incremental training failed for %s: %s", redacted_employee, exc)
         _dataset_embedding_cache.invalidate()
         raise
 
-    logger.info("Incremental training for %s complete.", employee_id)
+    logger.info("Incremental training for %s complete.", redacted_employee)
     _dataset_embedding_cache.invalidate()
     embedding_cache.invalidate_user_embeddings(employee_id)
     embedding_cache.invalidate_all_embeddings()  # Clear dataset index cache


### PR DESCRIPTION
Potential fix for [https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/36](https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/security/code-scanning/36)

To fix this without changing functionality, stop writing raw `employee_id` to logs and instead log a non-sensitive surrogate (for example, a short deterministic hash token) plus non-sensitive context (counts/status). This preserves observability while preventing private identifier leakage.

Best single approach in this file:
- Add a small helper function in `recognition/tasks.py` that converts `employee_id` into a redacted log-safe token (e.g., SHA-256 truncated digest).
- Update the affected log statement(s), including line 572, to use this redacted token instead of raw `employee_id`.
- Keep returned data and business logic unchanged (only logging changes).

This requires:
- One new standard-library import: `hashlib`.
- One helper method definition near other utility helpers.
- Replacement of log arguments in the shown logging lines within `incremental_face_training`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
