### PR TITLE
test: Fix flaky rate limit test due to minute boundary crossing

### DIFF
--- a/tests/recognition/test_face_recognition_api.py
+++ b/tests/recognition/test_face_recognition_api.py
@@ -1,7 +1,7 @@
 import json
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import django
 from django.core.cache import cache
@@ -84,7 +84,8 @@ def test_face_recognition_api_returns_match(client, monkeypatch):
         "anti_spoofing": False,
     },
 )
-def test_face_recognition_api_rate_limit(client, monkeypatch):
+@patch("django_ratelimit.core.time.time", return_value=1776240224.0)
+def test_face_recognition_api_rate_limit(mock_time, client, monkeypatch):
     cache.clear()
 
     monkeypatch.setattr(


### PR DESCRIPTION
The `test_face_recognition_api_rate_limit` test was flaky because it relied on actual wall-clock time for the `django-ratelimit` module. When the loop happened to cross a minute boundary (since it checks `rate="5/m"`), the rate limit window would reset, and the 6th request wouldn't receive the expected `429 Too Many Requests` response.

I added `@patch('django_ratelimit.core.time.time', return_value=1776240224.0)` to freeze time exclusively for that test function, ensuring it always executes within the exact same "minute" according to the rate limiter. Tested locally and against the full suite successfully.

---
*PR created automatically by Jules for task [6735885417132918925](https://jules.google.com/task/6735885417132918925) started by @saint2706*