### PR TITLE
Fix Docker publish workflow image references for Trivy/SBOM

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,13 +95,6 @@ jobs:
           flavor: |
             latest=false
 
-      - name: Prepare primary image tag
-        env:
-          META_TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          primary_tag="$(echo "$META_TAGS" | head -n 1)"
-          echo "PRIMARY_IMAGE_TAG=${primary_tag}" >> "$GITHUB_ENV"
-
       - name: Build and push Docker image
         id: build-and-push
         uses: docker/build-push-action@v6
@@ -131,7 +124,7 @@ jobs:
         uses: aquasecurity/trivy-action@v0.35.0
         continue-on-error: true
         with:
-          image-ref: ${{ env.PRIMARY_IMAGE_TAG }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
           format: sarif
           output: trivy-report.sarif
           vuln-type: os,library
@@ -150,7 +143,7 @@ jobs:
         id: trivy-sbom
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          image-ref: ${{ env.PRIMARY_IMAGE_TAG }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
           format: cyclonedx
           output: trivy-sbom.cdx.json
 


### PR DESCRIPTION
### Motivation
- The workflow used a derived “primary tag” which can be empty or unstable depending on event context, causing Trivy/SBOM steps to reference the wrong image and fail.

### Description
- Removed the `Prepare primary image tag` step from `.github/workflows/docker-publish.yml`.
- Updated the Trivy scan `image-ref` to use the immutable digest produced by `docker/build-push-action` as ``${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}``.
- Updated the SBOM generation `image-ref` to use the same digest-based reference to ensure the scan/SBOM target matches the built artifact exactly.

### Testing
- Ran `pre-commit run --files .github/workflows/docker-publish.yml` which completed successfully.
- Ran `pytest -q` which initially errored due to missing Django settings and test dependencies.
- Ran `DJANGO_SECRET_KEY=test-secret-key DJANGO_DEBUG=True pytest -q --ignore=tests/ui` which completed successfully with `441 passed, 3 skipped, 32 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df7a9635788330a94885f5792d3bab)