### PR TITLE
⚡ Bolt: Remove unused DB relations in AttendanceViewSet

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -56,3 +56,7 @@
 - **Problem**: Admin Action cards were rerendering unnecessarily on Dashboard state changes.
 - **Optimization**: Extracted `ActionCard` component in `frontend/src/components/ActionCard.tsx` and memoized it using `React.memo()`. Replaced inline `Link` tags in `frontend/src/pages/Dashboard.tsx` with `ActionCard` to improve React rendering efficiency.
 - **Result**: Reduced React rerenders in Dashboard.
+## Optimization: Removed unused query optimizations
+- **Problem**: The `AttendanceViewSet.get_queryset` in `recognition/api/views.py` used `.select_related("present_record", "time_record")` and `prefetch_related("user__groups", "user__user_permissions")` to optimize serialization. However, `AttendanceRecordSerializer` doesn't access these fields, it only needs the `user` relation for `get_username`.
+- **Optimization**: Removed the unused explicit `.select_related` and `prefetch_related` relations from the queryset, leaving only `.select_related("user")`.
+- **Result**: Reduced DB query complexity, preventing useless joins and extra prefetch queries that fetch data unused by the serializer.

--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -88,11 +88,15 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = PageNumberPagination
 
     def get_queryset(self):
+        # ⚡ Bolt: Removed unnecessary 'present_record', 'time_record' from select_related
+        # and 'user__groups', 'user__user_permissions' from prefetch_related since
+        # AttendanceRecordSerializer only needs 'user' to resolve the username.
+        # Expected impact: Reduced DB query complexity, preventing useless joins and
+        # extra prefetch queries that fetch data unused by the serializer.
         user = self.request.user
         queryset = (
             RecognitionAttempt.objects.all()
-            .select_related("user", "present_record", "time_record")
-            .prefetch_related("user__groups", "user__user_permissions")
+            .select_related("user")
             .order_by("-created_at")
         )
 

--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -94,11 +94,7 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
         # Expected impact: Reduced DB query complexity, preventing useless joins and
         # extra prefetch queries that fetch data unused by the serializer.
         user = self.request.user
-        queryset = (
-            RecognitionAttempt.objects.all()
-            .select_related("user")
-            .order_by("-created_at")
-        )
+        queryset = RecognitionAttempt.objects.all().select_related("user").order_by("-created_at")
 
         if not user.is_staff:
             queryset = queryset.filter(user=user)


### PR DESCRIPTION
Removed unused database relations from `AttendanceViewSet.get_queryset` to prevent fetching unused data and making unnecessary DB joins and queries, improving query performance.

---
*PR created automatically by Jules for task [5916276269963378559](https://jules.google.com/task/5916276269963378559) started by @saint2706*