### PR TITLE
🎨 Picasso: [UX improvement] Add tooltip to navigation brand and document UX audit

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -39,3 +39,10 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 * When adding a loading indicator, be sure to use `lucide-react`'s `Loader2` and make sure it is imported properly. It's common to miss the import when inserting the element. Always check lint and build to verify.
 
 - Added missing utility classes to index.css to ensure layout sizes and spacing work properly.
+
+## Audited Codebase
+- Confirmed that accessibility requirements are satisfied across the codebase.
+- No ARIA, visual polish, empty state or keyboard accessibility gaps found that require modification.
+
+## Enhancements
+- `Navbar.tsx`: Added a `title` attribute to the main brand `<Link>` providing a tooltip ("Return to Home") for better usability when hovering or focusing the element.

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -44,7 +44,7 @@ export const Navbar = () => {
     return (
         <nav className="navbar">
             <div className="navbar-container">
-                <Link to="/" className="navbar-brand">
+                <Link to="/" className="navbar-brand" title="Return to Home">
                     <UserCheck size={24} aria-hidden="true" />
                     <span>Smart Attendance</span>
                 </Link>


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Add tooltip to navigation brand and document UX audit

- Audited `frontend/src` for accessibility and UI gaps.
- Confirmed WCAG 2.5.3 compliance for `aria-label`s.
- Added a `title="Return to Home"` attribute to the main brand `<Link>` in `Navbar.tsx` to provide native tooltips for mouse and keyboard users.
- Logged UX audit and improvements in `.jules/picasso.md`.
- Verified changes with linting and building.

---
*PR created automatically by Jules for task [14298454594525974483](https://jules.google.com/task/14298454594525974483) started by @saint2706*