### PR TITLE
☸️ Kubernetes: Implement least privilege via custom ServiceAccount

### DIFF
--- a/k8s/base/celery-beat-deployment.yaml
+++ b/k8s/base/celery-beat-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/name: celery-beat
         app.kubernetes.io/component: scheduler
     spec:
-      serviceAccountName: default
+      serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/k8s/base/celery-deployment.yaml
+++ b/k8s/base/celery-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app.kubernetes.io/name: celery-worker
         app.kubernetes.io/component: worker
     spec:
-      serviceAccountName: default
+      serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: attendance-system
 
 resources:
   - namespace.yaml
+  - serviceaccount.yaml
   - networkpolicy.yaml
   - configmap.yaml
   - sealed-secret.yaml

--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: postgres
         app.kubernetes.io/component: database
     spec:
-      serviceAccountName: default
+      serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/name: redis
         app.kubernetes.io/component: cache
     spec:
-      serviceAccountName: default
+      serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true

--- a/k8s/base/serviceaccount.yaml
+++ b/k8s/base/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: attendance-sa
+  namespace: attendance-system
+  labels:
+    app.kubernetes.io/name: attendance-system
+    app.kubernetes.io/component: sa
+automountServiceAccountToken: false

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: web
         app.kubernetes.io/component: backend
     spec:
-      serviceAccountName: default
+      serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Created a dedicated `attendance-sa` ServiceAccount with `automountServiceAccountToken: false` and registered it in `kustomization.yaml`.
Updated `celery-beat`, `celery`, `postgres`, `redis`, and `web` deployments/statefulsets to use the new `attendance-sa` service account instead of the `default` one, enforcing least-privilege security.

---
*PR created automatically by Jules for task [940079914616575324](https://jules.google.com/task/940079914616575324) started by @saint2706*