### PR TITLE
📚 Docs: Fix broken screenshot link in USER_GUIDE.md

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -32,3 +32,4 @@
 - Fixed broken tutorial link in `.agents/skills/scikit-learn/references/quick_reference.md`
 - Fixed broken link to `Web Quality Audit` and `Core Web Vitals` in `.agents/skills/seo/SKILL.md` and `.agents/skills/accessibility/SKILL.md`
 - Fixed broken link to `[SKILL.md](../SKILL.md)` in `CLAUDE.md` to `[SKILL.md](.agents/skills/accessibility/SKILL.md)`
+- **2025-03-08 (Session 5)**: Audited user guide documentation. Corrected a broken link for the home page screenshot from `screenshots/home-light-updated.png` to `screenshots/home-light.png` in `docs/USER_GUIDE.md` and updated `CHANGELOG.md`. Verified markdown links again using `markdown-link-check`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This changelog was initially reconstructed from the git history on 2025-11-29, a
 
 ## [Unreleased]
 
+### Fixed
+
+- docs: Fix missing screenshot link `home-light-updated.png` in `docs/USER_GUIDE.md` to point to `home-light.png`
+
 ## [1.9.0] - 2026-04-17
 
 ### Fixed

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,7 +18,7 @@ If you are new to the system, start with the [Quick Start Guide](QUICKSTART.md) 
 
 1. Navigate to the system's home page.
 
-    ![Home page](screenshots/home-light-updated.png)
+    ![Home page](screenshots/home-light.png)
 
     *The home page shows the main actions: Mark Time-In, Mark Time-Out, and Dashboard Login.*
 


### PR DESCRIPTION
This PR fixes a broken screenshot image link in `docs/USER_GUIDE.md` where it erroneously referred to `home-light-updated.png` instead of the canonical `home-light.png`. It also updates the changelog and the docs-progress tracker files. All documentation links have been validated.

---
*PR created automatically by Jules for task [7087632972796340742](https://jules.google.com/task/7087632972796340742) started by @saint2706*