### PR TITLE
🐳 Docker: Optimize Dockerfiles for security and layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,9 @@ RUN apt-get update \
 
 # Upgrade system Python build tools to versions that resolve known CVEs.
 # (setuptools: CVE-2024-6345, CVE-2025-47273 | wheel: CVE-2026-24049)
-RUN pip install --no-cache-dir "setuptools>=78.1.1" "wheel>=0.46.2"
+# Ensure we patch the system python environment specifically,
+# not the venv which is already patched in the build stage.
+RUN /usr/local/bin/python -m pip install --no-cache-dir "setuptools>=78.1.1" "wheel>=0.46.2"
 
 # Create directories for runtime data and set ownership
 RUN mkdir -p /app/media /app/face_recognition_data /app/staticfiles \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -138,6 +138,14 @@ WORKDIR /app
 RUN groupadd --system --gid 1000 appgroup \
     && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
 
+# Apply Ubuntu security updates to patch OS-level CVEs from the base image.
+# Do this before copying app code to maximize layer caching.
+# hadolint ignore=DL3005
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy virtual environment and application
 COPY --from=build /venv /venv
 COPY --from=build /app /app


### PR DESCRIPTION
I have implemented Docker configuration improvements based on the "Docker" container optimization persona:
1. Improved security patching in `Dockerfile` by explicitly using `/usr/local/bin/python -m pip` to ensure `setuptools` and `wheel` are updated correctly outside the venv.
2. Handled CVE vulnerability patching in `Dockerfile.gpu` by issuing `apt-get update && apt-get upgrade` in the runtime base stage.
3. Repositioned the runtime OS patching above the `COPY --from=build` steps to ensure build layer caching remains effective. 

Changes have been tested successfully via `make lint` and `make test-all`.

---
*PR created automatically by Jules for task [16510256217200301283](https://jules.google.com/task/16510256217200301283) started by @saint2706*