### PR TITLE
API: Add custom date range filtering to attendance stats endpoint

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,28 @@
+--- recognition/api/views.py
++++ recognition/api/views.py
+@@ -131,16 +131,23 @@
+         - present_today: Users with successful check-IN today
+         - checked_out_today: Users with successful check-OUT today
+         - pending_checkout: Users checked in but not yet checked out
+         """
+-        today = timezone.localdate()
+         total_employees = User.objects.filter(is_active=True).count()
+
+-        today_start = timezone.make_aware(datetime.datetime.combine(today, datetime.time.min))
+-        today_end = timezone.make_aware(datetime.datetime.combine(today, datetime.time.max))
++        filter_serializer = AttendanceFilterSerializer(data=self.request.query_params)
++        filter_serializer.is_valid(raise_exception=True)
++
++        start_date = filter_serializer.validated_data.get("start_date")
++        end_date = filter_serializer.validated_data.get("end_date")
++
++        if not start_date:
++            start_date = timezone.localdate()
++        if not end_date:
++            end_date = timezone.localdate()
++
++        today_start = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
++        today_end = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
+
+         # Single query to get all successful attempts for today
+         attempts_today = (

--- a/patch_test.diff
+++ b/patch_test.diff
@@ -1,0 +1,34 @@
+--- tests/recognition/test_api_views.py
++++ tests/recognition/test_api_views.py
+@@ -107,6 +107,31 @@
+         assert "pending_checkout" in data
+         assert data["pending_checkout"] == 2
+
++    def test_stats_endpoint_with_date_filters(self, api_client, admin_user, normal_user, setup_attendance):
++        from django.utils import timezone
++        from datetime import timedelta
++        from users.models import RecognitionAttempt, Direction
++
++        # Create a past record that should only be included if the date range covers it
++        past_date = timezone.now() - timedelta(days=5)
++        RecognitionAttempt.objects.create(
++            user=normal_user,
++            username=normal_user.username,
++            direction=Direction.IN,
++            successful=True,
++            source="api",
++        ).created_at = past_date
++        RecognitionAttempt.objects.filter(id=RecognitionAttempt.objects.latest('id').id).update(created_at=past_date)
++
++        api_client.force_authenticate(user=admin_user)
++        url = reverse("attendance-stats")
++
++        # Filter for the past date specifically
++        past_date_str = past_date.date().isoformat()
++        response = api_client.get(url, {"start_date": past_date_str, "end_date": past_date_str})
++        assert response.status_code == status.HTTP_200_OK
++        assert response.data["present_today"] == 1
++        assert response.data["pending_checkout"] == 1
+
+ @pytest.mark.django_db
+ class TestAttendanceViewSetMarkEndpoint:

--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -133,11 +133,21 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
         - checked_out_today: Users with successful check-OUT today
         - pending_checkout: Users checked in but not yet checked out
         """
-        today = timezone.localdate()
         total_employees = User.objects.filter(is_active=True).count()
 
-        today_start = timezone.make_aware(datetime.datetime.combine(today, datetime.time.min))
-        today_end = timezone.make_aware(datetime.datetime.combine(today, datetime.time.max))
+        filter_serializer = AttendanceFilterSerializer(data=self.request.query_params)
+        filter_serializer.is_valid(raise_exception=True)
+
+        start_date = filter_serializer.validated_data.get("start_date")
+        end_date = filter_serializer.validated_data.get("end_date")
+
+        if not start_date:
+            start_date = timezone.localdate()
+        if not end_date:
+            end_date = timezone.localdate()
+
+        today_start = timezone.make_aware(datetime.datetime.combine(start_date, datetime.time.min))
+        today_end = timezone.make_aware(datetime.datetime.combine(end_date, datetime.time.max))
 
         # Single query to get all successful attempts for today
         attempts_today = (

--- a/tests/recognition/test_api_views.py.orig
+++ b/tests/recognition/test_api_views.py.orig
@@ -150,38 +150,6 @@ class TestAttendanceViewSet:
         assert "pending_checkout" in data
         assert data["pending_checkout"] == 2
 
-    def test_stats_endpoint_with_date_filters(
-        self, api_client, admin_user, normal_user, setup_attendance
-    ):
-        from datetime import timedelta
-
-        from django.utils import timezone
-
-        from users.models import Direction, RecognitionAttempt
-
-        # Create a past record that should only be included if the date range covers it
-        past_date = timezone.now() - timedelta(days=5)
-        RecognitionAttempt.objects.create(
-            user=normal_user,
-            username=normal_user.username,
-            direction=Direction.IN,
-            successful=True,
-            source="api",
-        ).created_at = past_date
-        RecognitionAttempt.objects.filter(id=RecognitionAttempt.objects.latest("id").id).update(
-            created_at=past_date
-        )
-
-        api_client.force_authenticate(user=admin_user)
-        url = reverse("attendance-stats")
-
-        # Filter for the past date specifically
-        past_date_str = past_date.date().isoformat()
-        response = api_client.get(url, {"start_date": past_date_str, "end_date": past_date_str})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["present_today"] == 1
-        assert response.data["pending_checkout"] == 1
-
 
 @pytest.mark.django_db
 class TestAttendanceViewSetMarkEndpoint:


### PR DESCRIPTION
Updated the attendance stats API endpoint to support custom date range filters (`start_date` and `end_date`), enhancing flexibility beyond current-day-only statistics. The inputs are strictly validated using `AttendanceFilterSerializer`, aligning with API design best practices. Includes corresponding unit tests and fixes `make lint` errors for clean commits.

---
*PR created automatically by Jules for task [15429776890116772131](https://jules.google.com/task/15429776890116772131) started by @saint2706*