### PR TITLE
☸️ Kubernetes: Fix prometheus scrape path in web deployment

### DIFF
--- a/.jules/kubernetes.md
+++ b/.jules/kubernetes.md
@@ -1,0 +1,1 @@
+- Fixed the Prometheus scrape path in web-deployment.yaml to point to the correct application metrics endpoint, preventing 404 errors during Prometheus scraping.

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8000"
-        prometheus.io/path: "/metrics"
+        prometheus.io/path: "/monitoring/metrics/"
       labels:
         app.kubernetes.io/name: web
         app.kubernetes.io/component: backend


### PR DESCRIPTION
## Problem
The `prometheus.io/path` annotation in the `web` deployment manifest was incorrectly set to `/metrics`. The actual metrics endpoint exposed by the application is `/monitoring/metrics/`. This mismatch causes Prometheus scraping to fail with 404 Not Found errors.

## Solution
Updated the `prometheus.io/path` annotation in `k8s/base/web-deployment.yaml` to `/monitoring/metrics/`.

## Verification
- Verified Kustomize builds for both `dev` and `production` overlays using `kubeconform` to ensure the generated YAML remains valid.
- Ran tests via `pytest` to ensure no functionality is broken.
- Ran formatters/linters via `make lint`.

---
*PR created automatically by Jules for task [11604657986360438686](https://jules.google.com/task/11604657986360438686) started by @saint2706*