### PR TITLE
🐳 Docker: Optimize layer caching by moving OS updates before COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,18 +95,18 @@ WORKDIR /app
 RUN groupadd --system --gid 1000 appgroup \
     && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
 
-# Copy virtual environment with installed dependencies
-COPY --from=build /venv /venv
-
-# Copy application code and collected static files
-COPY --from=build /app /app
-
 # Apply Debian security updates to patch OS-level CVEs from the base image.
 # hadolint ignore=DL3005
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy virtual environment with installed dependencies
+COPY --from=build /venv /venv
+
+# Copy application code and collected static files
+COPY --from=build /app /app
 
 # Upgrade system Python build tools to versions that resolve known CVEs.
 # (setuptools: CVE-2024-6345, CVE-2025-47273 | wheel: CVE-2026-24049)


### PR DESCRIPTION
Moved `apt-get update` and `apt-get upgrade` commands before copying the application code and virtual environment in the `Dockerfile` runtime stage. This maximizes layer caching by ensuring OS-level updates are cached independently of application code changes, leading to faster iterative builds.

Before: `apt-get update` ran after `COPY`, busting the cache on every code change.
After: `apt-get update` runs before `COPY`, preserving the OS update cache layer.

---
*PR created automatically by Jules for task [13166659623850251527](https://jules.google.com/task/13166659623850251527) started by @saint2706*