### PR TITLE
🎨 Picasso: [UX improvement] added focus visible styles to action cards

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -46,3 +46,4 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 
 ## Enhancements
 - `Navbar.tsx`: Added a `title` attribute to the main brand `<Link>` providing a tooltip ("Return to Home") for better usability when hovering or focusing the element.
+- Added focus-visible states to ActionCard components to improve keyboard navigation accessibility by giving a clear outline when tabbing through navigation cards.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -186,6 +186,11 @@ a:hover {
   transition: box-shadow var(--transition-normal), transform var(--transition-normal);
 }
 
+a.card:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+}
+
 .card:hover {
   box-shadow: var(--shadow-md);
 }


### PR DESCRIPTION
Added `:focus-visible` styling to `.card` elements that are links (`a.card:focus-visible`) in `index.css`.
This ensures proper keyboard navigation visibility for components like `ActionCard` when tabbing through the dashboard.

---
*PR created automatically by Jules for task [14390597899311811925](https://jules.google.com/task/14390597899311811925) started by @saint2706*