### PR TITLE
docs(k8s): explain why specific resource values, probes, and contexts were chosen

### DIFF
--- a/k8s/base/celery-beat-deployment.yaml
+++ b/k8s/base/celery-beat-deployment.yaml
@@ -23,6 +23,7 @@ spec:
     spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
+      # Pod-level security context enforces running as a non-root user for enhanced security.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -45,6 +46,7 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/256Mi for lightweight scheduling tasks)
           resources:
             requests:
               memory: "128Mi"
@@ -52,6 +54,7 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "100m"
+          # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
           livenessProbe:
             exec:
               command:
@@ -62,6 +65,7 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
+          # Readiness probe ensures traffic is only routed to the pod when it is fully ready to serve requests.
           readinessProbe:
             exec:
               command:
@@ -75,6 +79,7 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+          # Apply least-privilege security context to container to prevent privilege escalation.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/celery-deployment.yaml
+++ b/k8s/base/celery-deployment.yaml
@@ -21,6 +21,7 @@ spec:
     spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
+      # Pod-level security context enforces running as a non-root user for enhanced security.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -44,6 +45,7 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
           resources:
             requests:
               memory: "512Mi"
@@ -51,6 +53,7 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "1000m"
+          # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
           livenessProbe:
             exec:
               command:
@@ -61,6 +64,7 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
+          # Readiness probe ensures traffic is only routed to the pod when it is fully ready to serve requests.
           readinessProbe:
             exec:
               command:
@@ -78,6 +82,7 @@ spec:
               mountPath: /app/media
             - name: tmp
               mountPath: /tmp
+          # Apply least-privilege security context to container to prevent privilege escalation.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
+      # Pod-level security context enforces running as a non-root user for enhanced security.
       securityContext:
         runAsNonRoot: true
         runAsUser: 70
@@ -55,6 +56,7 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (256Mi/1Gi optimized for database caching)
           resources:
             requests:
               memory: "256Mi"
@@ -62,6 +64,7 @@ spec:
             limits:
               memory: "1Gi"
               cpu: "500m"
+          # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
           livenessProbe:
             exec:
               command:
@@ -72,6 +75,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+          # Readiness probe ensures traffic is only routed to the pod when it is fully ready to serve requests.
           readinessProbe:
             exec:
               command:
@@ -82,6 +86,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+          # Apply least-privilege security context to container to prevent privilege escalation.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
     spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
+      # Pod-level security context enforces running as a non-root user for enhanced security.
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -40,6 +41,7 @@ spec:
           command:
             - redis-server
             - /usr/local/etc/redis/redis.conf
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/512Mi to support in-memory caching and message brokering)
           resources:
             requests:
               memory: "128Mi"
@@ -47,6 +49,7 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "200m"
+          # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
           livenessProbe:
             exec:
               command:
@@ -56,6 +59,7 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+          # Readiness probe ensures traffic is only routed to the pod when it is fully ready to serve requests.
           readinessProbe:
             exec:
               command:
@@ -65,6 +69,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+          # Apply least-privilege security context to container to prevent privilege escalation.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -25,6 +25,7 @@ spec:
     spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
+      # Pod-level security context enforces running as a non-root user for enhanced security.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -45,6 +46,7 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
           resources:
             requests:
               memory: "512Mi"
@@ -52,6 +54,7 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "1000m"
+          # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
           livenessProbe:
             httpGet:
               path: /monitoring/metrics/
@@ -60,6 +63,7 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 10
             failureThreshold: 3
+          # Readiness probe ensures traffic is only routed to the pod when it is fully ready to serve requests.
           readinessProbe:
             httpGet:
               path: /monitoring/metrics/
@@ -75,6 +79,7 @@ spec:
               mountPath: /app/media
             - name: tmp
               mountPath: /tmp
+          # Apply least-privilege security context to container to prevent privilege escalation.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
Added inline documentation to `web`, `celery`, `celery-beat`, `postgres`, and `redis` deployments/statefulsets. The comments explain the rationale behind resource values, liveness/readiness probes, and security contexts to adhere to K8s best practices and improve observability.

---
*PR created automatically by Jules for task [12199654146047399183](https://jules.google.com/task/12199654146047399183) started by @saint2706*