### PR TITLE
docker: Optimize Dockerfile layer caching by moving pip install before COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,12 +102,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy virtual environment with installed dependencies
-COPY --from=build /venv /venv
-
-# Copy application code and collected static files
-COPY --from=build /app /app
-
 # Upgrade system Python build tools to versions that resolve known CVEs.
 # (setuptools: CVE-2024-6345, CVE-2025-47273 | wheel: CVE-2026-24049)
 # Ensure we patch the system python environment specifically,


### PR DESCRIPTION
Removed duplicate COPY instructions in the runtime stage of Dockerfile and ensured that the OS package patching via pip runs before the application code is copied. This maximizes Docker layer caching and eliminates redundancy. Tests and linters pass.

---
*PR created automatically by Jules for task [14788320696375065963](https://jules.google.com/task/14788320696375065963) started by @saint2706*