### PR TITLE
🐳 Docker: Optimize layer caching by removing duplicate COPY instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,12 +102,6 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy virtual environment with installed dependencies
-COPY --from=build /venv /venv
-
-# Copy application code and collected static files
-COPY --from=build /app /app
-
 # Upgrade system Python build tools to versions that resolve known CVEs.
 # (setuptools: CVE-2024-6345, CVE-2025-47273 | wheel: CVE-2026-24049)
 # Ensure we patch the system python environment specifically,


### PR DESCRIPTION
Fix duplicate COPY in Dockerfile to optimize layer caching

Removed redundant `COPY --from=build` instructions in the runtime stage of the Dockerfile. These instructions were placed before the system Python upgrade, meaning the application code and virtual environment were copied too early, invalidating the cache and resulting in larger image sizes. Removing them ensures the system dependencies are patched before application code is introduced.

---
*PR created automatically by Jules for task [12995478463682154131](https://jules.google.com/task/12995478463682154131) started by @saint2706*