### PR TITLE
🛡️ CI/CD: Pin GitHub Actions to explicit SHAs and resolve security warnings

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,7 +31,8 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -122,7 +122,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -169,7 +169,7 @@ jobs:
             --cov-report=term-missing
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334508  # v4
         if: always()
         with:
           name: coverage-report-${{ matrix.python-version }}
@@ -221,7 +221,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -298,7 +298,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -314,7 +314,7 @@ jobs:
             pyproject.toml
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319  # v4
         with:
           path: ~/.cache/ms-playwright
           key: >-

--- a/.github/workflows/close-all-prs.yml
+++ b/.github/workflows/close-all-prs.yml
@@ -11,6 +11,6 @@ jobs:
   close-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: crondaemon/close-pr@v1
+      - uses: crondaemon/close-pr@e80e1e69a47321a5e128cb5bba436eb1f32a76ed  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,20 +50,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@babb485cd094cc36239bc7a6af5160d2b516d7a4  # v3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@babb485cd094cc36239bc7a6af5160d2b516d7a4  # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@babb485cd094cc36239bc7a6af5160d2b516d7a4  # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@3b139cfc5fae8b618d3efa36728a59838077a1f3  # v4
         with:
           fail-on-severity: high
           deny-licenses: GPL-3.0, LGPL-3.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -68,11 +68,11 @@ jobs:
         run: echo "IMAGE_NAME=${IMAGE_NAME,,}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -80,7 +80,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@b32b51a8eda65d6793cd0494a773d4f6bcef32dc  # v6
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@e4df5e2fb42dfa52b8004fcf1cbb2ba601be386f  # v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
@@ -124,7 +124,7 @@ jobs:
       - name: Scan image with Trivy
         if: github.event_name != 'pull_request'
         id: trivy-scan
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@bdfd43c22421dbde57e841ba2dc0cc4634289870  # v0.35.0
         continue-on-error: true
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload Trivy scan report
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334508  # v4
         with:
           name: trivy-image-scan
           path: trivy-report.sarif
@@ -144,7 +144,7 @@ jobs:
       - name: Generate SBOM (CycloneDX)
         if: github.event_name != 'pull_request'
         id: trivy-sbom
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@bdfd43c22421dbde57e841ba2dc0cc4634289870  # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
           format: cyclonedx
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334508  # v4
         with:
           name: image-sbom
           path: trivy-sbom.cdx.json

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           persist-credentials: false
 
@@ -45,7 +45,7 @@ jobs:
 
       - name: Upload lint logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334508  # v4
         with:
           name: frontend-lint-logs-20
           path: frontend/.ci-logs/*.log
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           persist-credentials: false
 
@@ -85,7 +85,7 @@ jobs:
 
       - name: Upload build logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@1eb3cb2b3e0f29609092a73eb033bb759a334508  # v4
         with:
           name: frontend-build-logs-${{ matrix.node-version }}
           path: frontend/.ci-logs/*.log

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           fetch-depth: 1
           persist-credentials: false
@@ -88,12 +88,12 @@ jobs:
         run: python manage.py collectstatic --noinput
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@8f152de45cc393f58c3f4159c1da8112d6abc404  # v4
         with:
           node-version: "20"
 
       - name: Cache npm global packages
-        uses: actions/cache@v4
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319  # v4
         with:
           path: ~/.npm
           # Cache based on the OS and a hash of this workflow file

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4
         with:
           persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c  # v5
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: .pre-commit-config.yaml
       - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@46cb12b5093557e3f2824df9043216c52bb88a29  # v3.0.1


### PR DESCRIPTION
This PR fulfills the CI/CD persona requirements to optimize and secure our pipelines:
- **Dependency Pinning:** All actions (e.g., `actions/checkout@v4`, `docker/build-push-action@v6`) are now rigidly pinned to their exact commit SHAs. This prevents unauthorized execution of malicious code due to upstream supply chain attacks and adheres to GitHub's blanket security policy.
- **Security Suppression:** The `bump-version.yml` workflow intentionally requires credentials to push tags. Instead of breaking its functionality with `persist-credentials: false`, the `artipacked` warning is gracefully ignored via a zizmor directive inline.
- **Linting & Validation:** Yamllint and Zizmor have both confirmed zero violations, making our pipelines safer and standardized.

---
*PR created automatically by Jules for task [14524037725405965175](https://jules.google.com/task/14524037725405965175) started by @saint2706*