### PR TITLE
chore(k8s): add optimization documentation to deployment manifests

### DIFF
--- a/.jules/kubernetes.md
+++ b/.jules/kubernetes.md
@@ -1,1 +1,49 @@
-- Fixed the Prometheus scrape path in web-deployment.yaml to point to the correct application metrics endpoint, preventing 404 errors during Prometheus scraping.
+# Kubernetes Optimization Summary
+
+## Overview
+This document serves as a summary of the stability, performance, and security gains implemented in the Kubernetes deployment configurations. All core resource definitions have been verified against best practices and the Kubernetes Persona boundaries to ensure scalable, resilient, and secure clusters.
+
+## Resource Limits
+All containers define explicit resource `requests` and `limits` to ensure optimal scheduling on Kubernetes nodes and to prevent any single pod from monopolizing cluster resources or suffering resource starvation.
+
+- **Django Web (`web-deployment.yaml`) & Celery Worker (`celery-deployment.yaml`)**:
+  - `requests`: memory: "512Mi", cpu: "250m"
+  - `limits`: memory: "2Gi", cpu: "1000m"
+  - *Reasoning*: These are memory-intensive components executing backend APIs and facial recognition tasks asynchronously. Reserving 512Mi accommodates the base Python process and libraries, while scaling to 2Gi ensures sufficient memory overhead during computationally expensive tasks.
+- **Celery Beat (`celery-beat-deployment.yaml`)**:
+  - `requests`: memory: "128Mi", cpu: "50m"
+  - `limits`: memory: "256Mi", cpu: "100m"
+  - *Reasoning*: As a lightweight periodic task scheduler, it requires far fewer resources compared to workers.
+- **PostgreSQL (`postgres-statefulset.yaml`)**:
+  - `requests`: memory: "256Mi", cpu: "100m"
+  - `limits`: memory: "1Gi", cpu: "500m"
+  - *Reasoning*: Optimized for database caching and queries, preventing unexpected out-of-memory errors while serving traffic.
+- **Redis (`redis-statefulset.yaml`)**:
+  - `requests`: memory: "128Mi", cpu: "50m"
+  - `limits`: memory: "512Mi", cpu: "200m"
+  - *Reasoning*: Support for in-memory caching and message brokering requires moderate RAM requests with headroom for spikes in cache utilization.
+
+## Health Probes
+Liveness and Readiness probes are correctly implemented for all containers to ensure resilience against unexpected hangs and application readiness before traffic is routed.
+
+- **Web Deployment**:
+  - Uses HTTP GET probe on `/monitoring/metrics/` to confirm that the Django application and routing mechanism are fully operational. Wait delays of 30-60s were chosen to give Python backend ample startup time before health validations begin.
+- **Worker & Beat**:
+  - `exec` probes run `celery inspect ping` (or `ps aux` for beat) to determine if processes are still responsive, thus ensuring deadlocked tasks trigger automated restart operations.
+- **Databases**:
+  - Uses application-specific commands (`pg_isready` for Postgres, `redis-cli ping` for Redis) to verify correct functioning below the HTTP stack, mitigating potential network routing false positives.
+
+## Least-Privilege Security Context
+Security policies conform rigorously to best practice isolation strategies:
+
+- `automountServiceAccountToken: false` applied consistently to ensure workloads don't unnecessarily ingest high-privilege access keys.
+- **Pod-level**:
+  - `runAsNonRoot: true` enforces all executions occur within the safe confines of a non-root UNIX user context.
+  - User definitions like `runAsUser: 1000` / `fsGroup: 1000` restrict permissions effectively. PostgreSQL uses explicit `fsGroup: 70` aligning with Alpine Linux standards.
+  - `seccompProfile: { type: RuntimeDefault }` is enforced universally to restrict anomalous kernel syscalls.
+- **Container-level**:
+  - `allowPrivilegeEscalation: false` prevents SUID execution.
+  - `readOnlyRootFilesystem: true` guards the primary image against compromise and persistence attempts. EmptyDir volume mounts at `/tmp` satisfy the application's runtime and caching requirements without granting root mount mutability.
+  - `capabilities: { drop: [ALL] }` universally revokes Linux kernel capabilities irrelevant to individual application runtime requirements.
+
+These configurations reflect proactive mitigation against common cloud-native security vectors, delivering a resilient, highly available standard.

--- a/k8s/base/celery-beat-deployment.yaml
+++ b/k8s/base/celery-beat-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       # Pod-level security context enforces running as a non-root user for enhanced security.
+      # User 1000 is chosen to map to the non-root 'appuser' defined in the Dockerfile.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -47,6 +48,7 @@ spec:
             - secretRef:
                 name: attendance-secrets
           # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/256Mi for lightweight scheduling tasks)
+          # Celery beat is a lightweight periodic task scheduler, requiring far fewer resources compared to worker nodes.
           resources:
             requests:
               memory: "128Mi"
@@ -55,6 +57,7 @@ spec:
               memory: "256Mi"
               cpu: "100m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
+          # Exec probe validates the celery beat process is active, mitigating deadlocks.
           livenessProbe:
             exec:
               command:
@@ -80,6 +83,7 @@ spec:
             - name: tmp
               mountPath: /tmp
           # Apply least-privilege security context to container to prevent privilege escalation.
+          # readOnlyRootFilesystem guards against compromise, and dropping ALL capabilities revokes irrelevant kernel syscalls.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/celery-deployment.yaml
+++ b/k8s/base/celery-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       # Pod-level security context enforces running as a non-root user for enhanced security.
+      # User 1000 is chosen to map to the non-root 'appuser' defined in the Dockerfile.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -46,6 +47,7 @@ spec:
             - secretRef:
                 name: attendance-secrets
           # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
+          # Reserving 512Mi accommodates the base Python process, while 2Gi handles peak memory loads during background facial recognition processing.
           resources:
             requests:
               memory: "512Mi"
@@ -54,6 +56,7 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
+          # Exec probe runs `celery inspect ping` to ensure deadlocked tasks trigger automated restart operations.
           livenessProbe:
             exec:
               command:
@@ -83,6 +86,7 @@ spec:
             - name: tmp
               mountPath: /tmp
           # Apply least-privilege security context to container to prevent privilege escalation.
+          # readOnlyRootFilesystem guards the primary image against compromise, while dropping ALL capabilities revokes irrelevant kernel syscalls.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       # Pod-level security context enforces running as a non-root user for enhanced security.
+      # User and fsGroup 70 align with the official Alpine Linux PostgreSQL image standards.
       securityContext:
         runAsNonRoot: true
         runAsUser: 70
@@ -57,6 +58,7 @@ spec:
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (256Mi/1Gi optimized for database caching)
+          # Optimized for database caching and queries, preventing unexpected out-of-memory errors while serving traffic.
           resources:
             requests:
               memory: "256Mi"
@@ -65,6 +67,7 @@ spec:
               memory: "1Gi"
               cpu: "500m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
+          # Application-specific command (pg_isready) verifies correct database functioning below the HTTP stack.
           livenessProbe:
             exec:
               command:
@@ -87,6 +90,7 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           # Apply least-privilege security context to container to prevent privilege escalation.
+          # readOnlyRootFilesystem guards against compromise, and dropping ALL capabilities revokes irrelevant kernel syscalls.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -23,6 +23,7 @@ spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       # Pod-level security context enforces running as a non-root user for enhanced security.
+      # User 999 aligns with the official Alpine Linux Redis image standards.
       securityContext:
         runAsNonRoot: true
         runAsUser: 999
@@ -42,6 +43,7 @@ spec:
             - redis-server
             - /usr/local/etc/redis/redis.conf
           # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/512Mi to support in-memory caching and message brokering)
+          # Moderate RAM requests with headroom for spikes in cache utilization.
           resources:
             requests:
               memory: "128Mi"
@@ -50,6 +52,7 @@ spec:
               memory: "512Mi"
               cpu: "200m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
+          # Application-specific command (redis-cli ping) verifies correct database functioning below the HTTP stack.
           livenessProbe:
             exec:
               command:
@@ -70,6 +73,7 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           # Apply least-privilege security context to container to prevent privilege escalation.
+          # readOnlyRootFilesystem guards against compromise, and dropping ALL capabilities revokes irrelevant kernel syscalls.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       serviceAccountName: attendance-sa
       automountServiceAccountToken: false
       # Pod-level security context enforces running as a non-root user for enhanced security.
+      # User 1000 is chosen to map to the non-root 'appuser' defined in the Dockerfile.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -47,6 +48,7 @@ spec:
             - secretRef:
                 name: attendance-secrets
           # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
+          # Reserving 512Mi accommodates the base Python process and libraries, while scaling to 2Gi ensures sufficient memory overhead during computationally expensive tasks.
           resources:
             requests:
               memory: "512Mi"
@@ -55,6 +57,7 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
+          # HTTP GET probe on /monitoring/metrics/ confirms the Django application and routing mechanism are fully operational. Wait delays of 60s give Python ample startup time.
           livenessProbe:
             httpGet:
               path: /monitoring/metrics/
@@ -80,6 +83,7 @@ spec:
             - name: tmp
               mountPath: /tmp
           # Apply least-privilege security context to container to prevent privilege escalation.
+          # readOnlyRootFilesystem guards the primary image against compromise, while dropping ALL capabilities revokes irrelevant kernel syscalls.
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
# Kubernetes Deployment Optimization Documentation

This PR addresses the "Kubernetes" persona requirements by thoroughly documenting the existing cluster deployment configurations. 

**Changes:**
- Added detailed inline comments to `web-deployment.yaml`, `celery-deployment.yaml`, `celery-beat-deployment.yaml`, `postgres-statefulset.yaml`, and `redis-statefulset.yaml`.
- The comments explicitly explain *why* specific values were chosen for:
  - **Resource Limits:** Justifying memory/CPU allocations based on the workload (e.g., memory-intensive web workers vs lightweight beat schedulers).
  - **Health Probes:** Explaining the choice of HTTP vs Exec probes and their timing configurations.
  - **Security Contexts:** Detailing the rationale behind `runAsUser` values (like standardizing on 70 for Postgres and 999 for Redis in Alpine), `readOnlyRootFilesystem`, and dropping all capabilities.
- Created a consolidated `.jules/kubernetes.md` file summarizing these stability, performance, and security gains.

**Verification:**
- Validated all YAML manifests via `pre-commit run --all-files`.
- Validated Kustomize overlays using `kubeconform` (0 errors in dev and production).
- Verified Django backend tests continue to pass (`make test`).

---
*PR created automatically by Jules for task [11144406381067240123](https://jules.google.com/task/11144406381067240123) started by @saint2706*