### PR TITLE
🔧 Kubernetes: Fix YAML line-length violations

### DIFF
--- a/k8s/base/celery-beat-deployment.yaml
+++ b/k8s/base/celery-beat-deployment.yaml
@@ -47,7 +47,8 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
-          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/256Mi for lightweight scheduling tasks)
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation.
+          # (128Mi/256Mi for lightweight scheduling tasks)
           # Celery beat is a lightweight periodic task scheduler, requiring far fewer resources compared to worker nodes.
           resources:
             requests:

--- a/k8s/base/celery-deployment.yaml
+++ b/k8s/base/celery-deployment.yaml
@@ -46,7 +46,8 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
-          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation.
+          # (512Mi/2Gi for memory-intensive web/worker tasks)
           # Reserving 512Mi accommodates the base Python process, while 2Gi handles peak memory loads during background facial recognition processing.
           resources:
             requests:

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -42,7 +42,8 @@ spec:
           command:
             - redis-server
             - /usr/local/etc/redis/redis.conf
-          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (128Mi/512Mi to support in-memory caching and message brokering)
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation.
+          # (128Mi/512Mi to support in-memory caching and message brokering)
           # Moderate RAM requests with headroom for spikes in cache utilization.
           resources:
             requests:

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -47,8 +47,10 @@ spec:
                 name: attendance-config
             - secretRef:
                 name: attendance-secrets
-          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation. (512Mi/2Gi for memory-intensive web/worker tasks)
-          # Reserving 512Mi accommodates the base Python process and libraries, while scaling to 2Gi ensures sufficient memory overhead during computationally expensive tasks.
+          # Resource limits and requests defined for optimal scheduling and to prevent resource starvation.
+          # (512Mi/2Gi for memory-intensive web/worker tasks)
+          # Reserving 512Mi accommodates the base Python process and libraries,
+          # while scaling to 2Gi ensures sufficient memory overhead during computationally expensive tasks.
           resources:
             requests:
               memory: "512Mi"
@@ -57,7 +59,8 @@ spec:
               memory: "2Gi"
               cpu: "1000m"
           # Liveness probe ensures the pod is automatically restarted if it becomes unresponsive.
-          # HTTP GET probe on /monitoring/metrics/ confirms the Django application and routing mechanism are fully operational. Wait delays of 60s give Python ample startup time.
+          # HTTP GET probe on /monitoring/metrics/ confirms the Django application and routing mechanism
+          # are fully operational. Wait delays of 60s give Python ample startup time.
           livenessProbe:
             httpGet:
               path: /monitoring/metrics/


### PR DESCRIPTION
Split excessively long comments in Kubernetes deployment and statefulset manifests to resolve `yamllint` line-too-long errors. This improves readability and ensures full compliance with the established `.yamllint` configuration (max 150 chars). No functional changes to the orchestration or scaling logic.

---
*PR created automatically by Jules for task [10094199135721420387](https://jules.google.com/task/10094199135721420387) started by @saint2706*