### PR TITLE
Optimize Docker configurations and pin image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN pnpm run build
 # =============================================================================
 # Stage 2: Base Python Runtime
 # =============================================================================
+# hadolint ignore=DL3006
 FROM python:${PYTHON_VERSION}-slim-bookworm AS python-base
 
 ENV PYTHONUNBUFFERED=1 \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -33,6 +33,7 @@ RUN pnpm run build
 # =============================================================================
 # Stage 2: Base runtime with CUDA
 # =============================================================================
+# hadolint ignore=DL3006
 FROM nvidia/cuda:${CUDA_VERSION}-cudnn9-runtime-ubuntu22.04 AS cuda-base
 
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16.2-alpine
+    image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
     restart: unless-stopped
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-attendance}
@@ -17,7 +17,7 @@ services:
       retries: 5
 
   redis:
-    image: redis:7.2.13-alpine
+    image: redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38
     restart: unless-stopped
     ports:
       - "${REDIS_PORT:-6379}:6379"


### PR DESCRIPTION
The PR optimizes Docker configurations and implements container security best practices by explicitly pinning exact SHA256 digests for `postgres` and `redis` base images in `docker-compose.yml`. It also addresses `hadolint` unpinned base image warnings on parameterized Dockerfiles (`Dockerfile` and `Dockerfile.gpu`) using explicit ignore directives (`DL3006`), maintaining dynamic build arguments while keeping lint checks clean.

---
*PR created automatically by Jules for task [16029733640437586537](https://jules.google.com/task/16029733640437586537) started by @saint2706*