### PR TITLE
🔒 Kubernetes: Implement least-privilege network policies

### DIFF
--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -30,16 +30,58 @@ spec:
         - protocol: TCP
           port: 8000
 ---
-# Allow internal communication
+# Allow access to Redis from application components
+# Restricting internal communication enforces least privilege. By defining explicit access rules for Redis,
+# we prevent lateral movement in the event of a compromised pod, significantly increasing the resilience and security of the cluster.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: allow-internal
+  name: allow-redis-access
   namespace: attendance-system
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
   policyTypes:
     - Ingress
   ingress:
     - from:
-        - podSelector: {}
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - web
+                  - celery-worker
+                  - celery-beat
+      ports:
+        - protocol: TCP
+          port: 6379
+---
+# Allow access to PostgreSQL from application components
+# Restricting internal communication enforces least privilege. By defining explicit access rules for PostgreSQL,
+# we prevent lateral movement in the event of a compromised pod, significantly increasing the resilience and security of the cluster.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-postgres-access
+  namespace: attendance-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - web
+                  - celery-worker
+                  - celery-beat
+      ports:
+        - protocol: TCP
+          port: 5432


### PR DESCRIPTION
Replaces the overly permissive `allow-internal` NetworkPolicy, which allowed any pod to communicate with any other pod in the namespace, with targeted policies.

New explicit policies are added to only allow incoming traffic to Redis (port 6379) and PostgreSQL (port 5432) from the `web`, `celery-worker`, and `celery-beat` application components. This adheres to the principle of least privilege and improves cluster resilience by preventing lateral movement in the event of a compromised pod. Added explanatory documentation comments directly to the YAML as per the Kubernetes persona guidelines.

All manifests validated locally using `kubeconform` and all Python tests passed without regressions.

---
*PR created automatically by Jules for task [16756597326852266402](https://jules.google.com/task/16756597326852266402) started by @saint2706*