### PR TITLE
🔌 API: Add RFC 7807 tests for attendance-stats endpoint

### DIFF
--- a/tests/recognition/test_api_views.py
+++ b/tests/recognition/test_api_views.py
@@ -647,3 +647,20 @@ class TestAttendanceViewSetMarkEndpoint:
         assert "errors" in response.data
         assert response.data["instance"] == url
         assert response.content_type == "application/problem+json"
+
+    def test_attendance_stats_invalid_date_rfc7807(self, api_client, admin_user):
+        api_client.force_authenticate(user=admin_user)
+        from django.urls import reverse
+
+        url = reverse("attendance-stats")
+        response = api_client.get(url, {"start_date": "not-a-date"})
+
+        from rest_framework import status
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data["type"] == "about:blank"
+        assert response.data["status"] == status.HTTP_400_BAD_REQUEST
+        assert "start_date" in response.data["detail"]
+        assert "errors" in response.data
+        assert response.data["instance"] == url
+        assert response.content_type == "application/problem+json"


### PR DESCRIPTION
Added `test_attendance_stats_invalid_date_rfc7807` in `tests/recognition/test_api_views.py` to verify RFC 7807 Problem Details response on the `attendance-stats` endpoint when invalid query parameters are used.

---
*PR created automatically by Jules for task [1245422338859583567](https://jules.google.com/task/1245422338859583567) started by @saint2706*