### PR TITLE
Kubernetes optimizations: Add PDBs and configuration comments

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - celery-deployment.yaml
   - celery-beat-deployment.yaml
   - ingress.yaml
+  - pdb.yaml
 
 labels:
   - pairs:

--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -23,6 +23,7 @@ spec:
     - Ingress
   ingress:
     - from:
+        # Allow traffic specifically from the NGINX Ingress Controller namespace to securely route external traffic to the web pods.
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: ingress-nginx

--- a/k8s/base/pdb.yaml
+++ b/k8s/base/pdb.yaml
@@ -1,0 +1,33 @@
+# PodDisruptionBudget for web deployment
+# Ensures at least one web pod is available during voluntary disruptions (like node drains) to maintain service availability.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: web-pdb
+  namespace: attendance-system
+  labels:
+    app.kubernetes.io/name: web
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: attendance-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+---
+# PodDisruptionBudget for celery-worker deployment
+# Ensures at least one worker pod is available during voluntary disruptions to maintain background task processing.
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: celery-worker-pdb
+  namespace: attendance-system
+  labels:
+    app.kubernetes.io/name: celery-worker
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: attendance-system
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: celery-worker


### PR DESCRIPTION
Adds `PodDisruptionBudget` resources for the `web` and `celery-worker` deployments to ensure resilience and stability during voluntary cluster disruptions. Also adds an explanatory comment to the `ingress-nginx` namespace selector in `networkpolicy.yaml` to document the configuration choice.

---
*PR created automatically by Jules for task [8638251456878885768](https://jules.google.com/task/8638251456878885768) started by @saint2706*