### PR TITLE
🐳 Docker: Optimize layer caching for OS updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,18 +89,18 @@ ENV PATH="/venv/bin:$PATH" \
     DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.production \
     DJANGO_DEBUG=0
 
-WORKDIR /app
-
-# Create a non-root user for running the application
-RUN groupadd --system --gid 1000 appgroup \
-    && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
-
 # Apply Debian security updates to patch OS-level CVEs from the base image.
 # hadolint ignore=DL3005
 RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Create a non-root user for running the application
+RUN groupadd --system --gid 1000 appgroup \
+    && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
 
 # Upgrade system Python build tools to versions that resolve known CVEs.
 # (setuptools: CVE-2024-6345, CVE-2025-47273 | wheel: CVE-2026-24049)

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -132,12 +132,6 @@ ENV PATH="/venv/bin:$PATH" \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
-WORKDIR /app
-
-# Create non-root user
-RUN groupadd --system --gid 1000 appgroup \
-    && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
-
 # Apply Ubuntu security updates to patch OS-level CVEs from the base image.
 # Do this before copying app code to maximize layer caching.
 # hadolint ignore=DL3005
@@ -145,6 +139,12 @@ RUN apt-get update \
     && apt-get upgrade -y --no-install-recommends \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Create non-root user
+RUN groupadd --system --gid 1000 appgroup \
+    && useradd --system --uid 1000 --gid appgroup --shell /bin/bash --create-home appuser
 
 # Copy virtual environment and application
 COPY --from=build /venv /venv


### PR DESCRIPTION
This PR optimizes the Docker configurations to maximize layer caching.

In `Dockerfile` and `Dockerfile.gpu`, the base OS security updates (`apt-get update && apt-get upgrade`) were moved to the very top of the `runtime` stage.

Because system packages change infrequently, caching this layer before copying the application code or setting up users ensures faster builds. Lint checks via `hadolint` and `pre-commit` pass. Tests pass without regression.

---
*PR created automatically by Jules for task [7158789569266888424](https://jules.google.com/task/7158789569266888424) started by @saint2706*