### PR TITLE
📚 Docs: Fix broken commit range link in CHANGELOG.md

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -35,3 +35,4 @@
 - **2025-03-08 (Session 5)**: Audited user guide documentation. Corrected a broken link for the home page screenshot from `screenshots/home-light-updated.png` to `screenshots/home-light.png` in `docs/USER_GUIDE.md` and updated `CHANGELOG.md`. Verified markdown links again using `markdown-link-check`.
 - Documented `/admin/health/` endpoint in `docs/API_REFERENCE.md` as per issue #8 in `docs/GOOD_FIRST_ISSUES.md`.
 - Improved Troubleshooting Guide in `docs/troubleshooting.md` as per issue #2 in `docs/GOOD_FIRST_ISSUES.md`.
+- **2025-03-08 (Session 6)**: Audited codebase documentation for broken links. Fixed an invalid commit range link `v0.3.0...v1.0.0` in `CHANGELOG.md` to `35e67a0...v1.0.0`. Validated the fix via `markdown-link-check` and ensured build and linting checks (`make lint`, `pnpm run lint`) pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1745,7 +1745,7 @@ This version represents the state of the codebase when the original CHANGELOG.md
 [1.3.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2025-11-12&until=2025-11-18
 [1.2.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2025-11-09&until=2025-11-11
 [1.1.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2025-11-08&until=2025-11-09
-[1.0.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/compare/v0.3.0...v1.0.0
+[1.0.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/compare/35e67a0...v1.0.0
 [0.3.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2025-10-03&until=2025-10-29
 [0.2.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2025-09-28&until=2025-10-03
 [0.1.0]: https://github.com/saint2706/Attendance-Management-System-Using-Face-Recognition/commits/main?since=2023-11-19&until=2025-09-28


### PR DESCRIPTION
As a documentation custodian, I've audited the repository and fixed a broken link in the `CHANGELOG.md` file. I've also verified that the changes pass linting and testing steps.

---
*PR created automatically by Jules for task [6699602865625111029](https://jules.google.com/task/6699602865625111029) started by @saint2706*