### PR TITLE
🎨 Picasso: [UX improvement] Explicit width and height on lucide-react icons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -57,3 +57,4 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 - Added `aria-busy={isLoadingStats}` to the retry button in `Dashboard.tsx` to communicate loading state for statistics fetch.
 - Added `aria-busy={isInitializing}` to the retry camera access button in `MarkAttendance.tsx`.
 - Added `aria-busy={isProcessing}` to the capture and recognize button in `MarkAttendance.tsx` to improve feedback when the image is being processed.
+Replaced large `size` prop with explicit `width` and `height` props on `lucide-react` icons to prevent Cumulative Layout Shift (CLS) and fix Lighthouse issues regarding explicit sizing on SVG images.

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,4 @@
+🎨 Picasso: [UX improvement] Explicit width and height on lucide-react icons
+
+Replaced the shorthand `size` prop on `lucide-react` icons with explicit `width` and `height` properties to prevent Cumulative Layout Shift (CLS) and fix Lighthouse missing dimension audits.
+Also patched the React dependency version mismatch by bumping react-dom to 19.2.5.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "lucide-react": "^0.577.0",
     "picomatch": "4.0.4",
     "react": "19.2.5",
-    "react-dom": "^19.2.4",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.0",
     "zod": "^4.3.6"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -27,11 +27,11 @@ importers:
         specifier: 19.2.5
         version: 19.2.5
       react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.5)
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       react-router-dom:
         specifier: ^7.14.0
-        version: 7.14.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+        version: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1221,10 +1221,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.5
 
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
@@ -2486,26 +2486,26 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  react-dom@19.2.4(react@19.2.5):
+  react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
 
   react-refresh@0.18.0: {}
 
-  react-router-dom@7.14.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5):
+  react-router-dom@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
-      react-dom: 19.2.4(react@19.2.5)
-      react-router: 7.14.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+      react-router: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  react-router@7.14.0(react-dom@19.2.4(react@19.2.5))(react@19.2.5):
+  react-router@7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
       react: 19.2.5
       set-cookie-parser: 2.7.2
     optionalDependencies:
-      react-dom: 19.2.4(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,7 +24,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   if (isLoading) {
     return (
       <div className="flex flex-col items-center justify-center" style={{ minHeight: '60vh' }} role="status" aria-live="polite">
-        <Loader2 size={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
+        <Loader2 width={48} height={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
         <div className="animate-pulse text-muted">Loading...</div>
       </div>
     );
@@ -51,7 +51,7 @@ const AppContent = () => {
       <main id="main-content" className="container" style={{ paddingTop: 'var(--spacing-lg)', paddingBottom: 'var(--spacing-xl)' }} tabIndex={-1}>
         <Suspense fallback={
           <div className="flex flex-col items-center justify-center" style={{ minHeight: '60vh' }} role="status" aria-live="polite">
-            <Loader2 size={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
+            <Loader2 width={48} height={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
             <div className="animate-pulse text-muted">Loading...</div>
           </div>
         }>

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -28,7 +28,7 @@ export const ActionCard = React.memo(({ to, title, icon: Icon, heading, descript
     return (
         <Link to={to} className="action-card card card-elevated" title={title} aria-labelledby={headingId} aria-describedby={descId}>
             <div className="card-body">
-                <Icon size={32} className="action-icon" aria-hidden="true" />
+                <Icon width={32} height={32} className="action-icon" aria-hidden="true" />
                 <h3 id={headingId}>{heading}</h3>
                 <p id={descId} className="text-muted text-sm">
                     {description}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -89,7 +89,7 @@ export const Dashboard = () => {
                 <h2 className="section-title" id="stats-title">Quick Overview</h2>
                 {hasError ? (
                     <div className="text-center py-12 w-full card card-elevated" style={{ gridColumn: '1 / -1' }} role="alert" aria-live="assertive">
-                        <AlertTriangle size={48} className="mx-auto text-warning mb-sm" aria-hidden="true" />
+                        <AlertTriangle width={48} height={48} className="mx-auto text-warning mb-sm" aria-hidden="true" />
                         <h3 className="text-lg font-semibold mb-xs">Failed to load statistics</h3>
                         <p className="text-muted mb-md">We couldn't retrieve the latest dashboard data.</p>
                         <button onClick={() => fetchStats()} className="btn btn-secondary" title="Retry loading statistics" disabled={isLoadingStats} aria-busy={isLoadingStats}>
@@ -103,7 +103,7 @@ export const Dashboard = () => {
                     </div>
                 ) : !isLoadingStats && stats.totalEmployees === 0 ? (
                     <div className="text-center py-12 w-full card card-elevated" style={{ gridColumn: '1 / -1' }}>
-                        <Inbox size={48} className="mx-auto text-muted mb-sm" aria-hidden="true" />
+                        <Inbox width={48} height={48} className="mx-auto text-muted mb-sm" aria-hidden="true" />
                         <h3 className="text-lg font-semibold mb-xs">No employees yet</h3>
                         <p className="text-muted mb-md">Get started by registering your first employee.</p>
                         <Link to="/employees/register" className="btn btn-primary" title="Register your first employee">
@@ -123,7 +123,7 @@ export const Dashboard = () => {
                                         <p className="stat-value">{stats.totalEmployees}</p>
                                     )}
                                 </div>
-                                <Users size={32} className="stat-icon" aria-hidden="true" />
+                                <Users width={32} height={32} className="stat-icon" aria-hidden="true" />
                             </div>
                         </div>
                         <div className="stat-card card card-elevated stat-success">
@@ -136,7 +136,7 @@ export const Dashboard = () => {
                                         <p className="stat-value">{stats.presentToday}</p>
                                     )}
                                 </div>
-                                <UserCheck size={32} className="stat-icon" aria-hidden="true" />
+                                <UserCheck width={32} height={32} className="stat-icon" aria-hidden="true" />
                             </div>
                         </div>
                         <div className="stat-card card card-elevated stat-info">

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -77,7 +77,7 @@ export const Home = () => {
             <section className="hero" aria-labelledby="hero-title">
                 <div className="hero-content">
                     <ScanFace
-                        size={128}
+                        width={128} height={128}
                         className="hero-icon mb-md mx-auto"
                         aria-hidden="true"
                         style={{ color: 'var(--color-primary)' }}
@@ -114,7 +114,7 @@ export const Home = () => {
                 <div className="features-grid">
                     <article className="feature-card card card-elevated">
                         <div className="card-body text-center">
-                            <Zap size={32} className="feature-icon" aria-hidden="true" />
+                            <Zap width={32} height={32} className="feature-icon" aria-hidden="true" />
                             <h3>Fast & Accurate</h3>
                             <p className="text-muted">
                                 Advanced AI-powered face recognition ensures quick and precise attendance marking.
@@ -123,7 +123,7 @@ export const Home = () => {
                     </article>
                     <article className="feature-card card card-elevated">
                         <div className="card-body text-center">
-                            <Shield size={32} className="feature-icon" aria-hidden="true" />
+                            <Shield width={32} height={32} className="feature-icon" aria-hidden="true" />
                             <h3>Secure & Private</h3>
                             <p className="text-muted">
                                 Your biometric data is encrypted and stored securely with industry-standard protection.
@@ -132,7 +132,7 @@ export const Home = () => {
                     </article>
                     <article className="feature-card card card-elevated">
                         <div className="card-body text-center">
-                            <ChartBar size={32} className="feature-icon" aria-hidden="true" />
+                            <ChartBar width={32} height={32} className="feature-icon" aria-hidden="true" />
                             <h3>Detailed Reports</h3>
                             <p className="text-muted">
                                 Generate comprehensive attendance reports with visual analytics and export capabilities.
@@ -164,7 +164,7 @@ export const Home = () => {
             {/* Privacy Section */}
             <section className="privacy-notice card" aria-labelledby="privacy-title">
                 <div className="card-body text-center">
-                    <UserCheck size={32} className="feature-icon" aria-hidden="true" />
+                    <UserCheck width={32} height={32} className="feature-icon" aria-hidden="true" />
                     <h2 id="privacy-title">Your Privacy Matters</h2>
                     <p className="text-muted">
                         By using this system, you consent to the collection and processing of your facial data

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -65,7 +65,7 @@ export const Login = () => {
             />
             <div className="login-card card card-elevated">
                 <div className="login-header">
-                    <LogIn size={32} className="login-icon" aria-hidden="true" />
+                    <LogIn width={32} height={32} className="login-icon" aria-hidden="true" />
                     <h1 className="login-title">Welcome Back</h1>
                     <p className="login-subtitle text-muted">
                         Sign in to access your dashboard

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -228,7 +228,7 @@ export const MarkAttendance = () => {
             />
             <div className="attendance-container">
                 <header className="attendance-header">
-                    <Clock size={32} className="header-icon" aria-hidden="true" />
+                    <Clock width={32} height={32} className="header-icon" aria-hidden="true" />
                     <h1>Mark Time-{direction === 'in' ? 'In' : 'Out'}</h1>
                     <p className="text-muted">
                         Position your face in the camera and click capture
@@ -239,7 +239,7 @@ export const MarkAttendance = () => {
                 <div className="camera-container card card-elevated">
                     {error ? (
                         <div className="camera-error" role="alert" aria-live="assertive">
-                            <CameraOff size={48} aria-hidden="true" />
+                            <CameraOff width={48} height={48} aria-hidden="true" />
                             <p>{error}</p>
                             <button onClick={startCamera} className="btn btn-primary" title="Retry connecting to camera" disabled={isInitializing} aria-busy={isInitializing}>
                                 {isInitializing ? (
@@ -254,7 +254,7 @@ export const MarkAttendance = () => {
                         <>
                             {isInitializing && (
                                 <div className="flex flex-col items-center justify-center text-muted" role="status" aria-live="polite" style={{ position: 'absolute', inset: 0, zIndex: 10, backgroundColor: '#000' }}>
-                                    <Loader2 size={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
+                                    <Loader2 width={48} height={48} className="animate-spin mb-md" style={{ color: 'var(--color-primary)' }} aria-hidden="true" />
                                     <p>Starting camera...</p>
                                 </div>
                             )}
@@ -305,7 +305,7 @@ export const MarkAttendance = () => {
                         <div className="result-content">
                             {result.recognized ? (
                                 <>
-                                    <CheckCircle size={32} aria-hidden="true" />
+                                    <CheckCircle width={32} height={32} aria-hidden="true" />
                                     <div>
                                         <h2>Attendance Marked!</h2>
                                         <p>Welcome, {result.username}</p>
@@ -318,7 +318,7 @@ export const MarkAttendance = () => {
                                 </>
                             ) : result.spoofDetected ? (
                                 <>
-                                    <AlertTriangle size={32} aria-hidden="true" />
+                                    <AlertTriangle width={32} height={32} aria-hidden="true" />
                                     <div>
                                         <h2>Liveness Check Failed</h2>
                                         <p>Please try again with your actual face</p>
@@ -326,7 +326,7 @@ export const MarkAttendance = () => {
                                 </>
                             ) : (
                                 <>
-                                    <XCircle size={32} aria-hidden="true" />
+                                    <XCircle width={32} height={32} aria-hidden="true" />
                                     <div>
                                         <h2>Not Recognized</h2>
                                         <p>{result.message}</p>


### PR DESCRIPTION
🎨 Picasso: [UX improvement] Explicit width and height on lucide-react icons

Replaced the shorthand `size` prop on `lucide-react` icons with explicit `width` and `height` properties to prevent Cumulative Layout Shift (CLS) and fix Lighthouse missing dimension audits.
Also patched the React dependency version mismatch by bumping react-dom to 19.2.5.

---
*PR created automatically by Jules for task [16224124997051246624](https://jules.google.com/task/16224124997051246624) started by @saint2706*