### PR TITLE
docs: Fix false positive dead link for black python formatter

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -36,3 +36,4 @@
 - Documented `/admin/health/` endpoint in `docs/API_REFERENCE.md` as per issue #8 in `docs/GOOD_FIRST_ISSUES.md`.
 - Improved Troubleshooting Guide in `docs/troubleshooting.md` as per issue #2 in `docs/GOOD_FIRST_ISSUES.md`.
 - **2025-03-08 (Session 6)**: Audited codebase documentation for broken links. Fixed an invalid commit range link `v0.3.0...v1.0.0` in `CHANGELOG.md` to `35e67a0...v1.0.0`. Validated the fix via `markdown-link-check` and ensured build and linting checks (`make lint`, `pnpm run lint`) pass.
+- **2025-03-08 (Session 7)**: Audited codebase for dead links. Fixed a false positive dead link to `https://github.com/psf/black` by adding it to the `.markdownlinkcheck.json` ignore list. Verified `markdown-link-check` passes cleanly.

--- a/.markdownlinkcheck.json
+++ b/.markdownlinkcheck.json
@@ -59,6 +59,9 @@
     },
     {
       "pattern": "^\\.agents/skills/"
+    },
+    {
+      "pattern": "^https://github\\.com/psf/black"
     }
   ]
 }


### PR DESCRIPTION
Adds `^https://github\\.com/psf/black` to `.markdownlinkcheck.json` ignore list to resolve false positive dead link errors.

---
*PR created automatically by Jules for task [7306012259180446627](https://jules.google.com/task/7306012259180446627) started by @saint2706*