### PR TITLE
Fix yamllint indentation warning in bump-version.yml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-          # zizmor: ignore[artipacked]
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes a `yamllint` indentation warning in the `.github/workflows/bump-version.yml` pipeline configuration file by correctly aligning a `zizmor` ignore comment.

---
*PR created automatically by Jules for task [9762347277379518308](https://jules.google.com/task/9762347277379518308) started by @saint2706*