### PR TITLE
docs: Add /admin/health/ endpoint response example to API Reference

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -192,8 +192,61 @@ This endpoint provides a comprehensive overview of the system's health, includin
 
 #### Success Response (`200 OK`)
 
-The response is an HTML page rendering the health dashboard. The underlying data provided to the template includes:
+The response is an HTML page rendering the health dashboard. The underlying data provided to the template is roughly equivalent to the following JSON structure (which represents the context passed to the template):
 
+```json
+{
+    "snapshot": {
+        "status": "healthy",
+        "camera_tested": true,
+        "liveness_tested": true
+    },
+    "dataset": {
+        "exists": true,
+        "image_count": 150,
+        "identity_count": 5,
+        "last_updated": "2023-10-27T10:00:00Z",
+        "last_updated_display": "2023-10-27T10:00:00+00:00"
+    },
+    "model": {
+        "model_present": true,
+        "classes_present": true,
+        "report_present": true,
+        "last_trained": "2023-10-27T10:05:00Z",
+        "last_trained_display": "2023-10-27T10:05:00+00:00",
+        "stale": false
+    },
+    "evaluation_state": {
+        "latest_evaluation": {
+            "id": 1,
+            "evaluation_type": "scheduled_nightly",
+            "accuracy": 0.98,
+            "success": true
+        },
+        "trends": {
+            "accuracy": 0.01
+        },
+        "total_evaluations": 10,
+        "recent_failures": 0,
+        "scheduled_tasks_enabled": true
+    },
+    "recognition_state": {
+        "last_attempt": {
+            "username": "john_doe",
+            "direction": "In",
+            "timestamp": "2023-10-28T09:00:00Z",
+            "successful": true,
+            "spoof_detected": false
+        }
+    },
+    "worker_state": {
+        "status": "online",
+        "workers": 2
+    }
+}
+```
+
+This context data provides:
 - **Dataset Health:** Information about the training dataset, including the number of images, number of identities, and the last update timestamp.
 - **Model Health:** Status of the trained model artifacts (`svc.sav`, `classes.npy`, `classification_report.txt`) and whether the model is stale compared to the dataset.
 - **Evaluation Health:** Latest evaluation metrics (nightly, fairness, liveness), trends, total evaluations, and recent failures.


### PR DESCRIPTION
This PR addresses a missing piece of documentation identified in `docs/GOOD_FIRST_ISSUES.md`. The `/admin/health/` endpoint was missing documentation detailing its response structure. I've updated the `docs/API_REFERENCE.md` file to include a clear JSON example that demonstrates the shape of the data provided to the health dashboard template (including dataset status, model metadata, evaluations, recognition states, and worker info). I also ran `make lint`, `markdown-link-check`, and `make test-fast` to ensure the new docs format properly and no tests are broken.

---
*PR created automatically by Jules for task [6817518147764446583](https://jules.google.com/task/6817518147764446583) started by @saint2706*