### PR TITLE
🗄️ Database: Fix N+1 queries in attendance time views and analysis

### DIFF
--- a/recognition/analysis/attendance.py
+++ b/recognition/analysis/attendance.py
@@ -132,7 +132,9 @@ class AttendanceAnalytics:
         current_tz = timezone.get_current_timezone()
 
         # Prefetch all Time records
-        all_time_records = list(Time.objects.filter(**time_filters).order_by("time"))
+        all_time_records = list(
+            Time.objects.filter(**time_filters).select_related("user").order_by("time")
+        )
         time_records_by_key = defaultdict(list)
         for t in all_time_records:
             time_records_by_key[(t.user_id, t.date)].append(t)

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -3410,9 +3410,11 @@ def view_attendance_employee(request):
 
             user = User.objects.filter(username=username).first()
             if user:
-                time_qs = Time.objects.filter(
-                    user=user, date__gte=date_from, date__lte=date_to
-                ).order_by("-date")
+                time_qs = (
+                    Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                    .select_related("user")
+                    .order_by("-date")
+                )
                 present_qs = (
                     Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                     .select_related("user")
@@ -3457,9 +3459,11 @@ def view_my_attendance_employee_login(request):
                 messages.warning(request, "Invalid date selection.")
                 return redirect("view-my-attendance-employee-login")
 
-            time_qs = Time.objects.filter(
-                user=user, date__gte=date_from, date__lte=date_to
-            ).order_by("-date")
+            time_qs = (
+                Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                .select_related("user")
+                .order_by("-date")
+            )
             present_qs = (
                 Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                 .select_related("user")

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -3614,9 +3614,11 @@ def view_attendance_employee(request):
 
             user = User.objects.filter(username=username).first()
             if user:
-                time_qs = Time.objects.filter(
-                    user=user, date__gte=date_from, date__lte=date_to
-                ).order_by("-date")
+                time_qs = (
+                    Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                    .select_related("user")
+                    .order_by("-date")
+                )
                 present_qs = (
                     Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                     .select_related("user")
@@ -3661,9 +3663,11 @@ def view_my_attendance_employee_login(request):
                 messages.warning(request, "Invalid date selection.")
                 return redirect("view-my-attendance-employee-login")
 
-            time_qs = Time.objects.filter(
-                user=user, date__gte=date_from, date__lte=date_to
-            ).order_by("-date")
+            time_qs = (
+                Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                .select_related("user")
+                .order_by("-date")
+            )
             present_qs = (
                 Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                 .select_related("user")


### PR DESCRIPTION
This submission resolves N+1 query performance bottlenecks in Django views processing attendance time records. By chaining `.select_related("user")` to the `Time.objects` queries, the ORM now prefetches the associated user foreign key instances in a single `JOIN` query. This optimization has been applied consistently to the active views, legacy views, and the core analytics engine processing raw time logs. Pre-commit tests and linting check out cleanly.

---
*PR created automatically by Jules for task [17660446939256053340](https://jules.google.com/task/17660446939256053340) started by @saint2706*