### PR TITLE
ci: fix zizmor comment indentation to resolve yamllint error

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-          # zizmor: ignore[artipacked]
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixed the `yamllint` `comments-indentation` warning in `.github/workflows/bump-version.yml` caused by an improperly indented `zizmor` ignore comment. Validated the fix by running `yamllint` and `zizmor` individually, and running the `pre-commit run --all-files` pipeline.

---
*PR created automatically by Jules for task [14680194598347929851](https://jules.google.com/task/14680194598347929851) started by @saint2706*