### PR TITLE
📚 Docs: Fix broken screenshot links in DEVELOPER_GUIDE.md

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -608,16 +608,11 @@ The script logs in with the demo admin credentials and captures:
 
 | Screenshot            | Path                                         | Description                         |
 | --------------------- | -------------------------------------------- | ----------------------------------- |
-| Home page             | `screenshots/home.png`                       | Landing page with primary actions   |
+| Home page             | `docs/screenshots/home-light.png`                       | Landing page with primary actions   |
 | Login page            | `docs/screenshots/login.png`                 | User authentication screen          |
-| Admin dashboard       | `docs/screenshots/admin-dashboard.png`       | Admin home with first-run checklist |
-| Employee registration | `docs/screenshots/employee-registration.png` | Form for registering new employees  |
-| Employee enrollment   | `docs/screenshots/employee-enrollment.png`   | Photo capture for face recognition  |
-| Attendance session    | `docs/screenshots/attendance-session.png`    | Live recognition feed and logs      |
+| Admin dashboard       | `docs/screenshots/admin-dashboard-light.png`       | Admin home with first-run checklist |
+| Employee registration | `docs/screenshots/register.png` | Form for registering new employees  |
 | Reports               | `docs/screenshots/reports.png`               | Attendance reports dashboard        |
-| System health         | `docs/screenshots/system-health.png`         | Operational health dashboard        |
-| Fairness dashboard    | `docs/screenshots/fairness-dashboard.png`    | Per-group fairness metrics          |
-| Evaluation dashboard  | `screenshots/evaluation-dashboard.png`       | Model performance metrics           |
 
 ### Script Options
 


### PR DESCRIPTION
I have audited the documentation and fixed several broken image links in `docs/DEVELOPER_GUIDE.md` related to screenshots. I updated the paths to point to the correct files that exist in the repository (`home-light.png`, `admin-dashboard-light.png`, `register.png`) and removed rows for screenshots that do not currently exist in the `docs/screenshots/` folder. Finally, I successfully ran `markdown-link-check` across all markdown files to confirm there are no remaining broken links.

I have also run backend tests and frontend build/lint processes to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [2249495387045539071](https://jules.google.com/task/2249495387045539071) started by @saint2706*