### PR TITLE
🧪 Testing: Fixed flaky `test_mobile_navigation.py`

### DIFF
--- a/tests/ui/test_mobile_navigation.py
+++ b/tests/ui/test_mobile_navigation.py
@@ -99,8 +99,8 @@ def test_mobile_menu_closes_on_outside_click(mobile_page: Page, server_url: str)
     mobile_page.click("#mobile-menu-toggle")
     expect(nav_menu).to_have_class(re.compile(r"is-open"))
 
-    # Click outside the menu (on main content), forcing the click to bypass interceptions
-    mobile_page.click("#main-content", force=True)
+    # Click outside the menu (on body top-left), forcing the click to bypass interceptions
+    mobile_page.click("body", position={"x": 0, "y": 0})
 
     # Menu should be closed
     expect(nav_menu).not_to_have_class(re.compile(r"is-open"))


### PR DESCRIPTION
This change addresses a test failure in `tests/ui/test_mobile_navigation.py::test_mobile_menu_closes_on_outside_click` by refactoring an `force=True` interaction. Using `force=True` forces Playwright to bypass standard event bubbling checks, which frequently breaks automated CI flows with false-negative errors. By targeting `body` with explicit x,y coordinates, the test behavior better reflects user interactions for a more robust suite.

---
*PR created automatically by Jules for task [16601191585737443673](https://jules.google.com/task/16601191585737443673) started by @saint2706*