### PR TITLE
ci: Fix zizmor suppression indentation for yamllint in bump-version.yml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-          # zizmor: ignore[artipacked]
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes an indentation issue where `# zizmor: ignore[artipacked]` was not indented exactly the same as its surrounding keys (`uses:` and `with:`). This caused `yamllint` to throw a `comments-indentation` error. The fix aligns the comment to 8 spaces, resulting in zero errors from both `yamllint` and `zizmor` on the workflow files.

---
*PR created automatically by Jules for task [669342718923126541](https://jules.google.com/task/669342718923126541) started by @saint2706*