### PR TITLE
🔌 API: Fix mixed content types in API error responses

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -390,6 +390,26 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def http_method_not_allowed(self, request, *args, **kwargs):
+        logger.warning(
+            "Method Not Allowed (%s): %s",
+            request.method,
+            request.path,
+        )
+        response = JsonResponse(
+            {
+                "type": "about:blank",
+                "title": "Method Not Allowed",
+                "status": 405,
+                "detail": f"Method '{request.method}' not allowed.",
+                "instance": request.path,
+            },
+            status=405,
+            content_type="application/problem+json",
+        )
+        response["Allow"] = ", ".join(self._allowed_methods())
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -367,6 +367,26 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def http_method_not_allowed(self, request, *args, **kwargs):
+        logger.warning(
+            "Method Not Allowed (%s): %s",
+            request.method,
+            request.path,
+        )
+        response = JsonResponse(
+            {
+                "type": "about:blank",
+                "title": "Method Not Allowed",
+                "status": 405,
+                "detail": f"Method '{request.method}' not allowed.",
+                "instance": request.path,
+            },
+            status=405,
+            content_type="application/problem+json",
+        )
+        response["Allow"] = ", ".join(self._allowed_methods())
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 


### PR DESCRIPTION
🔌 API: Fix mixed content types in API error responses

The issue required enforcing API best practices, specifically regarding "mixed content types (e.g., returning HTML in a JSON API)."
The `FaceRecognitionAPI` views in both `recognition/views.py` and `recognition/views_legacy.py` are Django `View` classes. Because they did not implement `http_method_not_allowed`, Django was falling back to the generic `View.http_method_not_allowed` behavior, which returns an `HttpResponseNotAllowed` containing an HTML payload.

When clients (expecting a JSON API) sent an unsupported HTTP method (e.g., `GET` instead of `POST`), they would receive this HTML payload instead of a JSON response formatted as RFC 7807 Problem Details.

The fix overrides `http_method_not_allowed` in both `FaceRecognitionAPI` classes. It now returns a `JsonResponse` structured according to the RFC 7807 (Problem Details) specification, sets the `Content-Type` to `application/problem+json`, and properly includes the required `Allow` HTTP header in accordance with RFC 9110 to maintain HTTP standard compliance.

---
*PR created automatically by Jules for task [16718024978617663535](https://jules.google.com/task/16718024978617663535) started by @saint2706*