### PR TITLE
🔒 AIML: Disable pickle in np.load for security

### DIFF
--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -97,7 +97,7 @@ def load_existing_encodings(employee_id: str) -> np.ndarray:
         return np.empty((0, 0), dtype=np.float64)
 
     try:
-        return np.load(io.BytesIO(decrypted_bytes))
+        return np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.warning("Failed to deserialize encodings for %s: %s", employee_id, exc)
         return np.empty((0, 0), dtype=np.float64)


### PR DESCRIPTION
Fix security vulnerability in model loading by explicitly turning off pickle parsing in `np.load` within `recognition/tasks.py` since we do not need custom Python objects and only raw numpy primitives.

---
*PR created automatically by Jules for task [7799630259133897486](https://jules.google.com/task/7799630259133897486) started by @saint2706*