### PR TITLE
🤖 AIML: Removed insecure pickle usage in np.load

### DIFF
--- a/.jules/aiml_log.md
+++ b/.jules/aiml_log.md
@@ -1,1 +1,1 @@
-We removed allow_pickle=True to prevent security vulnerabilities and fixed tests calling obsolete methods
+🤖 AIML: Removed insecure pickle usage in np.load

--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -97,7 +97,7 @@ def load_existing_encodings(employee_id: str) -> np.ndarray:
         return np.empty((0, 0), dtype=np.float64)
 
     try:
-        return np.load(io.BytesIO(decrypted_bytes))
+        return np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.warning("Failed to deserialize encodings for %s: %s", employee_id, exc)
         return np.empty((0, 0), dtype=np.float64)


### PR DESCRIPTION
This fixes an issue found by the AIML specialist related to the use of `np.load` on untrusted input which could execute arbitrary code if malicious pickle payloads were embedded. We explicitly set `allow_pickle=False` in `recognition/tasks.py`.

---
*PR created automatically by Jules for task [7266012944109207609](https://jules.google.com/task/7266012944109207609) started by @saint2706*