### PR TITLE
ci: optimize pipeline security and fix linting errors

### DIFF
--- a/.github/actions/setup-frontend-env/action.yml
+++ b/.github/actions/setup-frontend-env/action.yml
@@ -18,12 +18,12 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
       with:
         version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
@@ -26,6 +26,8 @@ runs:
 
     - name: Install Python dependencies
       shell: bash
+      env:
+        REQUIREMENTS_FILE: ${{ inputs.requirements-file }}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r ${{ inputs.requirements-file }}
+        pip install -r "$REQUIREMENTS_FILE"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-          # zizmor: ignore[artipacked]
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR addresses multiple CI/CD pipeline improvements based on security and linting audits using `zizmor` and `yamllint`:

1.  **Dependency Pinning:** Pinned `actions/setup-node`, `actions/setup-python`, and `pnpm/action-setup` to explicit commit SHAs instead of mutable tags (`@v4`, `@v5`, `@v3`).
2.  **Script Injection Mitigation:** Updated the `.github/actions/setup-python-env/action.yml` step to read the `requirements-file` input via an environment variable (`$REQUIREMENTS_FILE`) rather than directly evaluating it within the `run` block.
3.  **YAML Formatting:** Corrected the indentation for a `# zizmor: ignore[artipacked]` comment in `bump-version.yml` to satisfy `yamllint`.

---
*PR created automatically by Jules for task [966947970896036127](https://jules.google.com/task/966947970896036127) started by @saint2706*