### PR TITLE
🔌 API: Fix 405 Method Not Allowed responses to include Allow header

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -1071,7 +1071,7 @@ def enqueue_attendance_batch(request):
     """Accept a batch of attendance records and enqueue them for Celery processing."""
 
     if request.method.upper() != "POST":
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "type": "about:blank",
                 "title": "Method Not Allowed",
@@ -1082,6 +1082,8 @@ def enqueue_attendance_batch(request):
             status=405,
             content_type="application/problem+json",
         )
+        response["Allow"] = "POST"
+        return response
 
     try:
         raw_body = request.body.decode(request.encoding or "utf-8") if request.body else "{}"

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -1065,7 +1065,7 @@ def enqueue_attendance_batch(request):
     """Accept a batch of attendance records and enqueue them for Celery processing."""
 
     if request.method.upper() != "POST":
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "type": "about:blank",
                 "title": "Method Not Allowed",
@@ -1076,6 +1076,8 @@ def enqueue_attendance_batch(request):
             status=405,
             content_type="application/problem+json",
         )
+        response["Allow"] = "POST"
+        return response
 
     try:
         raw_body = request.body.decode(request.encoding or "utf-8") if request.body else "{}"


### PR DESCRIPTION
Fix 405 Method Not Allowed responses to explicitly include the `Allow` HTTP header as required by RFC 9110 HTTP standards. This resolves a compliance issue where the `enqueue_attendance_batch` API endpoint correctly returned a 405 JSON response for non-POST requests but omitted the mandatory header.

---
*PR created automatically by Jules for task [11131353352235925182](https://jules.google.com/task/11131353352235925182) started by @saint2706*