### PR TITLE
🛡️ Sentinel: Enforce allow_pickle=False in np.load

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -67,3 +67,4 @@
 **Learning:** Explicitly configuring robust cryptographic algorithms (like Argon2) and enforcing strong password policies (min 12 characters) are essential defense-in-depth measures to protect user credentials against offline cracking attempts.
 **Prevention:** Updated `attendance_system_facial_recognition/settings/base.py` to explicitly enforce `Argon2PasswordHasher` as the primary hasher, and increased the `MinimumLengthValidator` to require 12 characters. Added `argon2-cffi` to `requirements.txt`.
 - Updated `postcss` in frontend to patch an XSS vulnerability (GHSA-qx2v-qp2m-jg93).
+Enforced allow_pickle=False in np.load

--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -97,7 +97,7 @@ def load_existing_encodings(employee_id: str) -> np.ndarray:
         return np.empty((0, 0), dtype=np.float64)
 
     try:
-        return np.load(io.BytesIO(decrypted_bytes))
+        return np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.warning("Failed to deserialize encodings for %s: %s", employee_id, exc)
         return np.empty((0, 0), dtype=np.float64)


### PR DESCRIPTION
Enforced `allow_pickle=False` in `np.load` calls to prevent insecure deserialization and arbitrary code execution risks.

---
*PR created automatically by Jules for task [14969169035893457706](https://jules.google.com/task/14969169035893457706) started by @saint2706*