### PR TITLE
🔒 AIML: Secure `np.load` deserialization

### DIFF
--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -97,7 +97,7 @@ def load_existing_encodings(employee_id: str) -> np.ndarray:
         return np.empty((0, 0), dtype=np.float64)
 
     try:
-        return np.load(io.BytesIO(decrypted_bytes))
+        return np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.warning("Failed to deserialize encodings for %s: %s", employee_id, exc)
         return np.empty((0, 0), dtype=np.float64)


### PR DESCRIPTION
Explicitly disabled `pickle` usage in `np.load` to ensure security against arbitrary code execution when loading encodings. This addresses the strict boundary for the AIML persona to never use `pickle` for untrusted data without verification.

---
*PR created automatically by Jules for task [13309636931074004374](https://jules.google.com/task/13309636931074004374) started by @saint2706*