### PR TITLE
🗄️ Database: Prevent N+1 queries in time_qs queries

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -3410,9 +3410,11 @@ def view_attendance_employee(request):
 
             user = User.objects.filter(username=username).first()
             if user:
-                time_qs = Time.objects.filter(
-                    user=user, date__gte=date_from, date__lte=date_to
-                ).order_by("-date")
+                time_qs = (
+                    Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                    .select_related("user")
+                    .order_by("-date")
+                )
                 present_qs = (
                     Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                     .select_related("user")
@@ -3457,9 +3459,11 @@ def view_my_attendance_employee_login(request):
                 messages.warning(request, "Invalid date selection.")
                 return redirect("view-my-attendance-employee-login")
 
-            time_qs = Time.objects.filter(
-                user=user, date__gte=date_from, date__lte=date_to
-            ).order_by("-date")
+            time_qs = (
+                Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                .select_related("user")
+                .order_by("-date")
+            )
             present_qs = (
                 Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                 .select_related("user")

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -3614,9 +3614,11 @@ def view_attendance_employee(request):
 
             user = User.objects.filter(username=username).first()
             if user:
-                time_qs = Time.objects.filter(
-                    user=user, date__gte=date_from, date__lte=date_to
-                ).order_by("-date")
+                time_qs = (
+                    Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                    .select_related("user")
+                    .order_by("-date")
+                )
                 present_qs = (
                     Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                     .select_related("user")
@@ -3661,9 +3663,11 @@ def view_my_attendance_employee_login(request):
                 messages.warning(request, "Invalid date selection.")
                 return redirect("view-my-attendance-employee-login")
 
-            time_qs = Time.objects.filter(
-                user=user, date__gte=date_from, date__lte=date_to
-            ).order_by("-date")
+            time_qs = (
+                Time.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
+                .select_related("user")
+                .order_by("-date")
+            )
             present_qs = (
                 Present.objects.filter(user=user, date__gte=date_from, date__lte=date_to)
                 .select_related("user")


### PR DESCRIPTION
This PR addresses N+1 query patterns in the `view_attendance_employee` and `view_my_attendance_employee_login` views across both the standard and legacy apps. Specifically, it ensures `time_qs` fetches the related `user` object in the initial query, mitigating excessive database hits when rendering attendance logic.

Changes:
- Appended `.select_related("user")` to `Time.objects.filter` queries in `recognition/views.py` (lines 3413 and 3460).
- Appended `.select_related("user")` to `Time.objects.filter` queries in `recognition/views_legacy.py` (lines 3617 and 3664).
- Verified tests and linters successfully.

---
*PR created automatically by Jules for task [10252713318023229524](https://jules.google.com/task/10252713318023229524) started by @saint2706*