### PR TITLE
🔄 CI/CD: Fix yamllint warning in bump-version.yml

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-          # zizmor: ignore[artipacked]
+        # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix yamllint comment indentation warning in bump-version.yml by aligning zizmor ignore comment with the step properties.

---
*PR created automatically by Jules for task [14909238904768337523](https://jules.google.com/task/14909238904768337523) started by @saint2706*