### PR TITLE
🤖 AIML: Explicitly set allow_pickle=False in np.load

### DIFF
--- a/recognition/tasks.py
+++ b/recognition/tasks.py
@@ -97,7 +97,7 @@ def load_existing_encodings(employee_id: str) -> np.ndarray:
         return np.empty((0, 0), dtype=np.float64)
 
     try:
-        return np.load(io.BytesIO(decrypted_bytes))
+        return np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)
     except Exception as exc:  # pragma: no cover - defensive programming
         logger.warning("Failed to deserialize encodings for %s: %s", employee_id, exc)
         return np.empty((0, 0), dtype=np.float64)


### PR DESCRIPTION
🤖 AIML: Explicitly set allow_pickle=False in np.load

**What:**
Updated `np.load(io.BytesIO(decrypted_bytes))` to `np.load(io.BytesIO(decrypted_bytes), allow_pickle=False)` in `recognition/tasks.py`.

**Why:**
To prevent arbitrary code execution vulnerabilities and avoid reliance on implicit defaults, enforcing the rule against using insecure pickle for untrusted data.

---
*PR created automatically by Jules for task [14922530728919472308](https://jules.google.com/task/14922530728919472308) started by @saint2706*