### PR TITLE
🔌 API: Set Allow header on 405 Method Not Allowed responses

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -1071,7 +1071,7 @@ def enqueue_attendance_batch(request):
     """Accept a batch of attendance records and enqueue them for Celery processing."""
 
     if request.method.upper() != "POST":
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "type": "about:blank",
                 "title": "Method Not Allowed",
@@ -1082,6 +1082,8 @@ def enqueue_attendance_batch(request):
             status=405,
             content_type="application/problem+json",
         )
+        response["Allow"] = "POST"
+        return response
 
     try:
         raw_body = request.body.decode(request.encoding or "utf-8") if request.body else "{}"

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -1065,7 +1065,7 @@ def enqueue_attendance_batch(request):
     """Accept a batch of attendance records and enqueue them for Celery processing."""
 
     if request.method.upper() != "POST":
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "type": "about:blank",
                 "title": "Method Not Allowed",
@@ -1076,6 +1076,8 @@ def enqueue_attendance_batch(request):
             status=405,
             content_type="application/problem+json",
         )
+        response["Allow"] = "POST"
+        return response
 
     try:
         raw_body = request.body.decode(request.encoding or "utf-8") if request.body else "{}"


### PR DESCRIPTION
I have modified the `enqueue_attendance_batch` view in both `recognition/views.py` and `recognition/views_legacy.py`. The `405 Method Not Allowed` JSON responses now explicitly include the `Allow` HTTP header set to `"POST"`, making them fully compliant with RFC 9110 standard HTTP response guidelines. All checks and tests passed successfully.

---
*PR created automatically by Jules for task [9829884970818572193](https://jules.google.com/task/9829884970818572193) started by @saint2706*