### PR TITLE
⚡ Bolt: Optimize present_qs to prevent N+1 query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -65,3 +65,5 @@
 - **Problem**: `AttendanceViewSet.get_queryset` in `recognition/api/views.py` filters `RecognitionAttempt` records by both `user` and `created_at` (date range). Without a composite index, the database may have to scan more rows or use an index that doesn't optimally support this combination.
 - **Optimization**: Added a composite index `models.Index(fields=["user", "created_at"], name="users_attempt_user_created_idx")` to the `RecognitionAttempt` model in `users/models.py`.
 - **Result**: Significantly faster query execution for user-specific attendance records over a time range, improving the responsiveness of attendance history lookups.
+
+- **Optimization**: Replaced `exists()` with `bool()` in `get_daily_trends` and `get_department_summary` to prevent redundant queries (N+1-like issue) when the queryset is iterated over immediately afterwards.

--- a/recognition/analysis/attendance.py
+++ b/recognition/analysis/attendance.py
@@ -97,7 +97,7 @@ class AttendanceAnalytics:
             Present.objects.filter(**filters).select_related("user").order_by("date", "user_id")
         )
 
-        if not present_records.exists():
+        if not present_records:
             return {
                 "start_date": start_date,
                 "end_date": end_date,
@@ -217,7 +217,7 @@ class AttendanceAnalytics:
 
         present_qs = Present.objects.filter(**filters).select_related("user")
 
-        if not present_qs.exists():
+        if not present_qs:
             return {
                 "start_date": start_date,
                 "end_date": end_date,


### PR DESCRIPTION
Optimized `get_daily_trends` and `get_department_summary` functions in `recognition/analysis/attendance.py` by replacing redundant `.exists()` calls with implicit boolean evaluations. This ensures that the queryset is cached during the truthiness check and prevents a subsequent full `SELECT` query when iterating over the objects immediately after, thus resolving an N+1-like database hit scenario.

---
*PR created automatically by Jules for task [2187185885937067597](https://jules.google.com/task/2187185885937067597) started by @saint2706*