### PR TITLE
🎨 Picasso: [UX improvement] Add global focus styles for anchor tags

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -58,3 +58,4 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 - Added `aria-busy={isInitializing}` to the retry camera access button in `MarkAttendance.tsx`.
 - Added `aria-busy={isProcessing}` to the capture and recognize button in `MarkAttendance.tsx` to improve feedback when the image is being processed.
 Replaced large `size` prop with explicit `width` and `height` props on `lucide-react` icons to prevent Cumulative Layout Shift (CLS) and fix Lighthouse issues regarding explicit sizing on SVG images.
+- Added `:focus-visible` styling directly to the base `a` element in `frontend/src/index.css` to ensure all unmarked links (like the 'Back to Home' links or main navigation text links) provide clear keyboard focus indicators.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,6 +102,12 @@ a:hover {
   color: var(--color-primary-hover);
 }
 
+a:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 /* Buttons */
 .btn {
   display: inline-flex;


### PR DESCRIPTION
Adds global `:focus-visible` styling to anchor tags (`a`) using the `--color-border-focus` design token. This ensures all text links, like the "Back to Home" links or implicit navigation items, provide clear visual indicators when navigated by keyboard users, fixing accessibility gaps where `.btn` or `.card` classes were not applied.

---
*PR created automatically by Jules for task [2650059433836980463](https://jules.google.com/task/2650059433836980463) started by @saint2706*