### PR TITLE
🔄 CI/CD: Pin actions and fix template injection

### DIFF
--- a/.github/actions/setup-frontend-env/action.yml
+++ b/.github/actions/setup-frontend-env/action.yml
@@ -18,12 +18,12 @@ runs:
   using: "composite"
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
       with:
         version: ${{ inputs.pnpm-version }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
@@ -26,6 +26,8 @@ runs:
 
     - name: Install Python dependencies
       shell: bash
+      env:
+        REQUIREMENTS_FILE: ${{ inputs.requirements-file }}
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install -r ${{ inputs.requirements-file }}
+        pip install -r "$REQUIREMENTS_FILE"


### PR DESCRIPTION
This PR implements CI/CD optimizations and security fixes:
- Pins GitHub Actions in composite workflows to specific SHAs to prevent supply-chain attacks.
- Resolves a high-severity template injection vulnerability flagged by `zizmor` in the Python setup action.

---
*PR created automatically by Jules for task [2006774577217854161](https://jules.google.com/task/2006774577217854161) started by @saint2706*