### PR TITLE
🧪 Testing: Fix flaky Playwright force click in mobile navigation tests

### DIFF
--- a/tests/ui/test_mobile_navigation.py
+++ b/tests/ui/test_mobile_navigation.py
@@ -100,7 +100,7 @@ def test_mobile_menu_closes_on_outside_click(mobile_page: Page, server_url: str)
     expect(nav_menu).to_have_class(re.compile(r"is-open"))
 
     # Click outside the menu (on main content), forcing the click to bypass interceptions
-    mobile_page.click("#main-content", force=True)
+    mobile_page.click("body", position={"x": 0, "y": 0})
 
     # Menu should be closed
     expect(nav_menu).not_to_have_class(re.compile(r"is-open"))


### PR DESCRIPTION
Replaced `page.click("#main-content", force=True)` with a click on safe coordinates `page.click("body", position={"x": 0, "y": 0})` in `tests/ui/test_mobile_navigation.py` to test outside click menu closures without bypassing Playwright's actionability checks.

---
*PR created automatically by Jules for task [13544935239284024027](https://jules.google.com/task/13544935239284024027) started by @saint2706*