### PR TITLE
🧘 Buddha: [SEO improvement] Add missing h1 tag to MarkAttendance

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -29,3 +29,4 @@
 - [GEO] Enhanced llms.txt site architecture for AI discoverability across all 3 files
 
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
+- [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -517,3 +517,4 @@ kbd.kbd-lg {
   font-size: 1em;
   min-width: 1.75em;
 }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -211,6 +211,7 @@ export const MarkAttendance = () => {
 
     return (
         <main className="mark-attendance animate-fade-in">
+            <h1 className="sr-only">Mark Attendance</h1>
             <title>Mark Attendance - Smart Attendance System</title>
             <meta name="description" content="Mark your time-in or time-out using face recognition." />
             <meta name="robots" content="noindex, nofollow" />


### PR DESCRIPTION
As the Buddha persona, I audited the frontend pages to ensure they follow semantic HTML hierarchy guidelines. I noticed `MarkAttendance.tsx` lacked a top-level `<h1>` element, which is necessary for Core Web Vitals/SEO scoring. I added a visually hidden `<h1 className="sr-only">Mark Attendance</h1>` to the page and added the `.sr-only` CSS class to `index.css`. This ensures AI vectors and screen readers can properly identify the main topic of the page without disrupting the visual UX layout. Also logged the progress in `.jules/buddha-scroll.md`.

---
*PR created automatically by Jules for task [16357381165925343564](https://jules.google.com/task/16357381165925343564) started by @saint2706*