### PR TITLE
🎨 Picasso: [UX improvement] - WCAG 2.5.3 compliance and dynamic tooltips

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -64,3 +64,5 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 
 - Added `aria-errormessage` attributes to the username and password input fields in `Login.tsx` to properly associate the error messages with the inputs for screen reader users, improving form accessibility and validation feedback.
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
+- Removed redundant `aria-label` on elements containing descriptive visible text (WCAG 2.5.3: Label in Name).
+- Added dynamic `title` tooltips to status indicators in UI dashboards for improved contextual assistance.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -78,7 +78,7 @@ export const Dashboard = () => {
                     <p className="text-muted">{getGreeting()}, {user?.username}!</p>
                 </div>
                 <div className="header-actions">
-                    <Link to="/setup-wizard" className="btn btn-primary" title="Start the Setup Wizard" aria-label="Start Setup Wizard">
+                    <Link to="/setup-wizard" className="btn btn-primary" title="Start the Setup Wizard">
                         Setup Wizard
                     </Link>
                 </div>
@@ -155,7 +155,7 @@ export const Dashboard = () => {
                                             <span className="sr-only">Loading system status...</span>
                                         </>
                                     ) : (
-                                        <p className="stat-value stat-status">
+                                        <p className="stat-value stat-status" title={`System status: ${stats.status}`}>
                                             <Activity size={20} aria-hidden="true" />
                                             {stats.status}
                                         </p>


### PR DESCRIPTION
# 🎨 Picasso: [UX improvement]

## Before
- The "Setup Wizard" `<Link>` inside `Dashboard.tsx` had an explicit `aria-label="Start Setup Wizard"`, causing a mismatch with the visible text "Setup Wizard", which slightly conflicts with strict WCAG 2.5.3 (Label in Name) criteria.
- The system status indicator lacked a tooltip describing its dynamic value, making it potentially harder to interpret for users requiring additional context.

## After
- Removed the redundant `aria-label` from the "Setup Wizard" link since its inner visible text already serves correctly as its accessible name.
- Appended a dynamic `title` tooltip mapping directly to the `stats.status` state to the `<p className="stat-value stat-status">` to provide descriptive context on hover.

---
*PR created automatically by Jules for task [141848992738394604](https://jules.google.com/task/141848992738394604) started by @saint2706*