### PR TITLE
🧪 Testing: Fix flake8 line too long errors

### DIFF
--- a/recognition/admin_views.py
+++ b/recognition/admin_views.py
@@ -177,8 +177,12 @@ def failure_analysis(request: HttpRequest) -> HttpResponse:
         fa_df = df[df["failure_type"] == "false_accept"]
         fr_df = df[df["failure_type"] == "false_reject"]
 
-        context["false_accepts"] = list(fa_df.to_dict("records")) if not bool(fa_df.empty) else []  # type: ignore[assignment]
-        context["false_rejects"] = list(fr_df.to_dict("records")) if not bool(fr_df.empty) else []  # type: ignore[assignment]
+        context["false_accepts"] = (
+            list(fa_df.to_dict("records")) if not bool(fa_df.empty) else []
+        )  # type: ignore[assignment]
+        context["false_rejects"] = (
+            list(fr_df.to_dict("records")) if not bool(fr_df.empty) else []
+        )  # type: ignore[assignment]
         context["failures_available"] = True
 
     if subgroup_csv.exists():

--- a/recognition/analysis/attendance.py
+++ b/recognition/analysis/attendance.py
@@ -233,8 +233,8 @@ class AttendanceAnalytics:
         group_memberships = (
             Group.objects.filter(user__id__in=user_ids).values("user__id", "name").order_by("name")
         )
-        # Since a user could be in multiple groups, we keep the first one found (as it's ordered by name)
-        # similar to the previous behavior which used .first()
+        # Since a user could be in multiple groups, we keep the first one found
+        # (as it's ordered by name) similar to the previous behavior which used .first()
         for membership in group_memberships:
             uid = membership["user__id"]
             if uid not in user_departments:

--- a/tests/recognition/test_api_views.py
+++ b/tests/recognition/test_api_views.py
@@ -299,7 +299,10 @@ class TestAttendanceViewSetMarkEndpoint:
 
         monkeypatch.setattr("cv2.imdecode", lambda *args, **kwargs: None)
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -307,8 +310,8 @@ class TestAttendanceViewSetMarkEndpoint:
 
     @pytest.fixture
     def api_client(self):
-        # By redefining api_client inside the class, we ensure a new client for each test,
-        # though the main issue is rate-limiting based on IP/User. Let's patch get_rate for the test.
+        # By redefining api_client inside the class, we ensure a new client for each test.
+        # Let's patch get_rate for the test to avoid rate-limiting issues.
         return APIClient()
 
     @pytest.fixture(autouse=True)
@@ -335,7 +338,10 @@ class TestAttendanceViewSetMarkEndpoint:
 
         monkeypatch.setattr(DeepFace, "represent", mock_represent)
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -358,7 +364,10 @@ class TestAttendanceViewSetMarkEndpoint:
 
         monkeypatch.setattr(DeepFace, "represent", mock_represent)
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -393,14 +402,18 @@ class TestAttendanceViewSetMarkEndpoint:
         )
 
         # Mock dataset with unparseable embeddings
+        def mock_load(*args, **kwargs):
+            return [{"embedding": "invalid string not an array", "username": "admin"}]
+
         monkeypatch.setattr(
             "recognition.views._load_dataset_embeddings_for_matching",
-            lambda *args, **kwargs: [
-                {"embedding": "invalid string not an array", "username": "admin"}
-            ],
+            mock_load,
         )
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -434,23 +447,34 @@ class TestAttendanceViewSetMarkEndpoint:
             lambda *args, **kwargs: (np.zeros(128), {"x": 0, "y": 0, "w": 100, "h": 100}),
         )
 
+        def mock_load_data(*args, **kwargs):
+            return [{"embedding": np.ones(128), "username": admin_user.username}]
+
         monkeypatch.setattr(
             "recognition.views._load_dataset_embeddings_for_matching",
-            lambda *args, **kwargs: [{"embedding": np.ones(128), "username": admin_user.username}],
+            mock_load_data,
         )
 
-        # Force pipeline.find_closest_dataset_match to return a match with high distance (low confidence)
-        monkeypatch.setattr(
-            pipeline,
-            "find_closest_dataset_match",
-            lambda *args, **kwargs: (
+        # Force pipeline.find_closest_dataset_match to return a match with
+        # high distance (low confidence)
+        def mock_find(*args, **kwargs):
+            # distance 0.99 is above the 0.6 threshold for cosine
+            return (
                 admin_user.username,
                 0.99,
                 "dataset/admin/1.jpg",
-            ),  # distance 0.99 is above the 0.6 threshold for cosine
+            )
+
+        monkeypatch.setattr(
+            pipeline,
+            "find_closest_dataset_match",
+            mock_find,
         )
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -485,19 +509,28 @@ class TestAttendanceViewSetMarkEndpoint:
             lambda *args, **kwargs: (np.zeros(128), {"x": 0, "y": 0, "w": 100, "h": 100}),
         )
 
+        def mock_load_data(*args, **kwargs):
+            return [{"embedding": np.zeros(128), "username": "ghost_user"}]
+
         monkeypatch.setattr(
             "recognition.views._load_dataset_embeddings_for_matching",
-            lambda *args, **kwargs: [{"embedding": np.zeros(128), "username": "ghost_user"}],
+            mock_load_data,
         )
 
         # Force match with distance 0.0
+        def mock_find(*args, **kwargs):
+            return ("ghost_user", 0.0, "dataset/ghost/1.jpg")
+
         monkeypatch.setattr(
             pipeline,
             "find_closest_dataset_match",
-            lambda *args, **kwargs: ("ghost_user", 0.0, "dataset/ghost/1.jpg"),
+            mock_find,
         )
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -531,26 +564,35 @@ class TestAttendanceViewSetMarkEndpoint:
             lambda *args, **kwargs: (np.zeros(128), {"x": 0, "y": 0, "w": 100, "h": 100}),
         )
 
+        def mock_load_data(*args, **kwargs):
+            return [{"embedding": np.zeros(128), "username": admin_user.username}]
+
         monkeypatch.setattr(
             "recognition.views._load_dataset_embeddings_for_matching",
-            lambda *args, **kwargs: [{"embedding": np.zeros(128), "username": admin_user.username}],
+            mock_load_data,
         )
+
+        def mock_find(*args, **kwargs):
+            return (
+                admin_user.username,
+                0.0,
+                f"dataset/{admin_user.username}/1.jpg",
+            )
 
         monkeypatch.setattr(
             pipeline,
             "find_closest_dataset_match",
-            lambda *args, **kwargs: (
-                admin_user.username,
-                0.0,
-                f"dataset/{admin_user.username}/1.jpg",
-            ),
+            mock_find,
         )
 
         from recognition import views
 
         monkeypatch.setattr(views, "update_attendance_in_db_out", lambda *args, **kwargs: None)
 
-        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA"
+            "SUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64, "direction": "out"})
 
         assert response.status_code == status.HTTP_200_OK
@@ -585,26 +627,35 @@ class TestAttendanceViewSetMarkEndpoint:
             lambda *args, **kwargs: (np.zeros(128), {"x": 0, "y": 0, "w": 100, "h": 100}),
         )
 
+        def mock_load_data(*args, **kwargs):
+            return [{"embedding": np.zeros(128), "username": admin_user.username}]
+
         monkeypatch.setattr(
             "recognition.views._load_dataset_embeddings_for_matching",
-            lambda *args, **kwargs: [{"embedding": np.zeros(128), "username": admin_user.username}],
+            mock_load_data,
         )
+
+        def mock_find(*args, **kwargs):
+            return (
+                admin_user.username,
+                0.0,
+                f"dataset/{admin_user.username}/1.jpg",
+            )
 
         monkeypatch.setattr(
             pipeline,
             "find_closest_dataset_match",
-            lambda *args, **kwargs: (
-                admin_user.username,
-                0.0,
-                f"dataset/{admin_user.username}/1.jpg",
-            ),
+            mock_find,
         )
 
         from recognition import views
 
         monkeypatch.setattr(views, "update_attendance_in_db_in", lambda *args, **kwargs: None)
 
-        valid_png_b64 = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        valid_png_b64 = (
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42"
+            "mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        )
         response = api_client.post(url, {"image": valid_png_b64})
 
         assert response.status_code == status.HTTP_200_OK

--- a/tests/recognition/test_models.py
+++ b/tests/recognition/test_models.py
@@ -516,7 +516,8 @@ class TestThresholdProfileSiteFallbackEmptyHit(TestCase):
 class TestThresholdProfileDefaultsFallbackHitEmpty2(TestCase):
     @override_settings(RECOGNITION_DISTANCE_THRESHOLD=0.6)
     def test_get_threshold_for_group_no_group_or_site_matches_no_default(self):
-        # We pass fallback_site="unknown_site" -> profile is not found, default profile does not exist
+        # We pass fallback_site="unknown_site" -> profile is not found,
+        # default profile does not exist.
         # Falls back to settings.RECOGNITION_DISTANCE_THRESHOLD
         assert (
             ThresholdProfile.get_threshold_for_group(

--- a/tests/recognition/test_pipeline.py
+++ b/tests/recognition/test_pipeline.py
@@ -127,7 +127,8 @@ def test_extract_all_embeddings_list_of_lists() -> None:
     # Each item must be valid for extract_embedding.
     # If the item is a list (e.g., [0.1, 0.2]), extract_embedding sees it as list of length 2
     # but the logic there expects representations as either a list of dicts or list of lists.
-    # Passing [[[0.1, 0.2]], [[0.3, 0.4]]] allows extract_embedding to parse each internal list properly.
+    # Passing [[[0.1, 0.2]], [[0.3, 0.4]]] allows extract_embedding to parse
+    # each internal list properly.
     payload = [[[0.1, 0.2]], [[0.3, 0.4]]]
     results = pipeline.extract_all_embeddings(payload)
     assert len(results) == 2
@@ -299,7 +300,9 @@ def test_find_closest_match_faiss_invalid_index() -> None:
     """Invalid FAISS index type should return None."""
     probe = np.array([0.9, 0.1], dtype=float)
     assert pipeline.find_closest_match_faiss(probe, None) is None  # type: ignore[arg-type]
-    assert pipeline.find_closest_match_faiss(probe, "not_faiss_index") is None  # type: ignore[arg-type]
+    assert (
+        pipeline.find_closest_match_faiss(probe, "not_faiss_index") is None
+    )  # type: ignore[arg-type]
 
 
 def test_find_closest_match_faiss_empty_probe() -> None:


### PR DESCRIPTION
Fixed flake8 lint errors in Python files and tests which break the pipeline.

---
*PR created automatically by Jules for task [12596958717230879032](https://jules.google.com/task/12596958717230879032) started by @saint2706*