### PR TITLE
🔄 CI/CD: Configure dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:

--- a/.jules/cicd.md
+++ b/.jules/cicd.md
@@ -12,3 +12,6 @@
 
 ## Further checks required
 - None
+
+## Dependabot update
+- Added `github-actions` ecosystem to `.github/dependabot.yml` per best practices to ensure actions updates are managed.


### PR DESCRIPTION
Configured Dependabot to track `github-actions` updates, maintaining security best practices for pinned action versions.

---
*PR created automatically by Jules for task [8659470348064370365](https://jules.google.com/task/8659470348064370365) started by @saint2706*