### PR TITLE
🎨 Picasso: Add title tooltips to Dashboard stats and Navbar user badge

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -18,7 +18,7 @@ Added aria-live for loading states, improved aria-labelledby for sections, and a
 
 - Replaced broken raster hero image (`/icons/icon-512.png`) with an accessible SVG `ScanFace` icon from Lucide React to gracefully handle missing static assets and match application aesthetics.
 - Replaced hardcoded Tailwind-like classes (`bg-gray-200`) in Dashboard statistics skeletons with a new reusable, theme-aware CSS `.skeleton` class so loading skeletons correctly adjust visibility during dark mode.
-## UX Improvements\n- Added `Escape` key accessibility for closing the mobile menu in the Navbar.
+## UX Improvements- Added `Escape` key accessibility for closing the mobile menu in the Navbar.
 \n- Confirmed `Space` and `Escape` keyboard accessibility is working in MarkAttendance.tsx for capture and reset actions.
 # Picasso UX Improvements
 
@@ -64,3 +64,4 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 
 - Added `aria-errormessage` attributes to the username and password input fields in `Login.tsx` to properly associate the error messages with the inputs for screen reader users, improving form accessibility and validation feedback.
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
+- Added title tooltips to dynamic stat values in Dashboard.tsx and user badge in Navbar.tsx to improve usability.

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -67,7 +67,7 @@ export const Navbar = () => {
                                 </li>
                                 {user && (
                                     <li className="nav-user">
-                                        <span className="badge badge-info">{user.username}</span>
+                                        <span className="badge badge-info" title={`Logged in as ${user.username}`}>{user.username}</span>
                                     </li>
                                 )}
                             </>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -123,7 +123,7 @@ export const Dashboard = () => {
                                             <span className="sr-only">Loading total employees...</span>
                                         </>
                                     ) : (
-                                        <p className="stat-value">{stats.totalEmployees}</p>
+                                        <p className="stat-value" title={`Total Employees: ${stats.totalEmployees}`}>{stats.totalEmployees}</p>
                                     )}
                                 </div>
                                 <Users width={32} height={32} className="stat-icon" aria-hidden="true" />
@@ -139,7 +139,7 @@ export const Dashboard = () => {
                                             <span className="sr-only">Loading present today...</span>
                                         </>
                                     ) : (
-                                        <p className="stat-value">{stats.presentToday}</p>
+                                        <p className="stat-value" title={`Present Today: ${stats.presentToday}`}>{stats.presentToday}</p>
                                     )}
                                 </div>
                                 <UserCheck width={32} height={32} className="stat-icon" aria-hidden="true" />
@@ -155,7 +155,7 @@ export const Dashboard = () => {
                                             <span className="sr-only">Loading system status...</span>
                                         </>
                                     ) : (
-                                        <p className="stat-value stat-status">
+                                        <p className="stat-value stat-status" title={`System Status: ${stats.status}`}>
                                             <Activity size={20} aria-hidden="true" />
                                             {stats.status}
                                         </p>


### PR DESCRIPTION
- Added `title` tooltips to the elements displaying "Total Employees", "Present Today", and "System Status" in the `Dashboard.tsx` component. This allows users to view the underlying dynamic values on hover.
- Added a `title` tooltip ("Logged in as {username}") to the user badge `span` element in the `Navbar.tsx` component to provide better context on user identity.
- Appended learning to `.jules/picasso.md`.
- Verified changes with passing unit tests, linters, and frontend UI confirmation.

---
*PR created automatically by Jules for task [1204656883057435584](https://jules.google.com/task/1204656883057435584) started by @saint2706*