### PR TITLE
🔌 API: Enforce consistent RFC 7807 problem details on match failure

### DIFF
--- a/recognition/api/views.py
+++ b/recognition/api/views.py
@@ -7,7 +7,7 @@ from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_headers
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
-from rest_framework import permissions, status, viewsets
+from rest_framework import permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
@@ -318,19 +318,10 @@ class AttendanceViewSet(viewsets.ReadOnlyModelViewSet):
         )
 
         if match_result is None:
-            response = Response(
-                {
-                    "type": "about:blank",
-                    "title": "Match Failed",
-                    "status": status.HTTP_200_OK,
-                    "detail": "Face recognized but no match found in database",
-                    "instance": request.path,
-                    "recognition": {"detected": True, "matched": False},
-                },
-                status=status.HTTP_200_OK,
+            raise RecognitionException(
+                {"detail": "Face recognized but no match found in database"},
+                recognition_data={"detected": True, "matched": False},
             )
-            response.content_type = "application/problem+json"
-            return response
 
         matched_username, distance, _ = match_result
 

--- a/tests/recognition/test_api_views.py
+++ b/tests/recognition/test_api_views.py
@@ -406,6 +406,52 @@ class TestAttendanceViewSetMarkEndpoint:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "No valid embeddings available for matching" in response.data["detail"]
 
+    def test_mark_match_result_is_none(self, api_client, admin_user, monkeypatch):
+        api_client.force_authenticate(user=admin_user)
+        url = reverse("attendance-mark")
+
+        import numpy as np
+
+        monkeypatch.setattr(
+            "cv2.imdecode", lambda *args, **kwargs: np.zeros((100, 100, 3), dtype=np.uint8)
+        )
+
+        from deepface import DeepFace
+
+        monkeypatch.setattr(
+            DeepFace,
+            "represent",
+            lambda *args, **kwargs: [
+                {"embedding": np.zeros(128), "facial_area": {"x": 0, "y": 0, "w": 100, "h": 100}}
+            ],
+        )
+
+        from recognition import pipeline
+
+        monkeypatch.setattr(
+            pipeline,
+            "extract_embedding",
+            lambda *args, **kwargs: (np.zeros(128), {"x": 0, "y": 0, "w": 100, "h": 100}),
+        )
+
+        monkeypatch.setattr(
+            "recognition.views._load_dataset_embeddings_for_matching",
+            lambda *args, **kwargs: [{"embedding": np.ones(128), "username": admin_user.username}],
+        )
+
+        monkeypatch.setattr(
+            pipeline,
+            "find_closest_dataset_match",
+            lambda *args, **kwargs: None,
+        )
+
+        valid_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+        response = api_client.post(url, {"image": valid_png_b64})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Face recognized but no match found in database" in response.data["detail"]
+        assert response.data["recognition"]["matched"] is False
+
     def test_mark_match_below_threshold(self, api_client, admin_user, monkeypatch):
         api_client.force_authenticate(user=admin_user)
         url = reverse("attendance-mark")


### PR DESCRIPTION
This PR addresses an API consistency issue in `AttendanceViewSet.mark()`. Previously, if face recognition succeeded but the user was not found in the database, the API would manually construct an error payload and return it with a `200 OK` HTTP status code. 

To comply with API design best practices and ensure consistent error handling, this branch replaces the manual response with a `RecognitionException`. This exception automatically integrates with the custom exception handler to produce a `400 Bad Request` status along with a correctly formatted RFC 7807 problem details response. An unused `status` import was also removed to maintain a clean build.

Tested by adding a dedicated automated test to cover the no-match branch (`test_mark_match_result_is_none`), and running the full test suite and linters to verify correctness.

---
*PR created automatically by Jules for task [9667206773537363655](https://jules.google.com/task/9667206773537363655) started by @saint2706*