### PR TITLE
☸️ Kubernetes: Fix yamllint missing document start warnings

### DIFF
--- a/.jules/kubernetes.md
+++ b/.jules/kubernetes.md
@@ -48,3 +48,6 @@ Security policies conform rigorously to best practice isolation strategies:
 
 These configurations reflect proactive mitigation against common cloud-native security vectors, delivering a resilient, highly available standard.
 Kubernetes configurations have been verified and optimized. Resource limits, liveness/readiness probes, and least-privilege security contexts (including automountServiceAccountToken: false and runAsNonRoot: true) are fully implemented and verified across all deployments.
+
+## YAML Formatting Improvements
+- Resolved `yamllint` warnings across all Kubernetes manifests by explicitly adding the `---` sequence to signify the start of a YAML document. This enforces standardized YAML formatting across the `k8s/` directory and improves consistency when processed by automated deployment tools.

--- a/k8s/base/celery-beat-deployment.yaml
+++ b/k8s/base/celery-beat-deployment.yaml
@@ -1,3 +1,4 @@
+---
 # Celery Beat scheduler deployment for periodic tasks
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/celery-deployment.yaml
+++ b/k8s/base/celery-deployment.yaml
@@ -1,3 +1,4 @@
+---
 # Celery worker deployment for async task processing
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,3 +1,4 @@
+---
 # ConfigMap for non-sensitive Django configuration
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,3 +1,4 @@
+---
 # Ingress for external traffic routing
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Kustomize base configuration
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,3 +1,4 @@
+---
 # Kubernetes namespace for the Attendance System
 apiVersion: v1
 kind: Namespace

--- a/k8s/base/networkpolicy.yaml
+++ b/k8s/base/networkpolicy.yaml
@@ -1,3 +1,4 @@
+---
 # Default deny all ingress for attendance-system namespace
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/k8s/base/pdb.yaml
+++ b/k8s/base/pdb.yaml
@@ -1,3 +1,4 @@
+---
 # PodDisruptionBudget for web deployment
 # Ensures at least one web pod is available during voluntary disruptions (like node drains) to maintain service availability.
 apiVersion: policy/v1

--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -1,3 +1,4 @@
+---
 # PostgreSQL StatefulSet for database persistence
 apiVersion: apps/v1
 kind: StatefulSet

--- a/k8s/base/pvc.yaml
+++ b/k8s/base/pvc.yaml
@@ -1,3 +1,4 @@
+---
 # PersistentVolumeClaims for shared application data
 ---
 # Face recognition training data storage

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -1,3 +1,4 @@
+---
 # Redis StatefulSet for Celery broker and cache
 apiVersion: apps/v1
 kind: StatefulSet

--- a/k8s/base/sealed-secret.yaml
+++ b/k8s/base/sealed-secret.yaml
@@ -1,3 +1,4 @@
+---
 # SealedSecret template for sensitive configuration
 # IMPORTANT: In production, generate this using kubeseal
 apiVersion: bitnami.com/v1alpha1

--- a/k8s/base/serviceaccount.yaml
+++ b/k8s/base/serviceaccount.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/k8s/base/web-deployment.yaml
+++ b/k8s/base/web-deployment.yaml
@@ -1,3 +1,4 @@
+---
 # Django web application deployment
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/base/web-service.yaml
+++ b/k8s/base/web-service.yaml
@@ -1,3 +1,4 @@
+---
 # Web service for internal cluster communication
 apiVersion: v1
 kind: Service

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Development overlay - single replicas, debug mode
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/k8s/overlays/production/hpa.yaml
+++ b/k8s/overlays/production/hpa.yaml
@@ -1,3 +1,4 @@
+---
 # Horizontal Pod Autoscaler for production
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,3 +1,4 @@
+---
 # Production overlay - HA, GPU, production secrets
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
As part of the Kubernetes optimization process, this PR enforces standard YAML formatting by ensuring all Kubernetes manifest files explicitly begin with the `---` document start sequence. This resolves warnings raised by `yamllint` (`document-start` rule) and improves standardisation. 

Key changes:
- Prepended `---` to all manifests within `k8s/base/` and `k8s/overlays/`.
- Updated the `.jules/kubernetes.md` summary to reflect this styling standardization.
- Verified that these changes pass frontend builds and backend regression tests.

---
*PR created automatically by Jules for task [8170367398816758926](https://jules.google.com/task/8170367398816758926) started by @saint2706*