### PR TITLE
🔄 CI/CD: Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:

--- a/.jules/cicd.md
+++ b/.jules/cicd.md
@@ -12,3 +12,6 @@
 
 ## Further checks required
 - None
+
+## Recent Improvements
+- Added `github-actions` to `dependabot.yml` to track and update pinned SHA versions for GitHub Actions dependencies automatically.


### PR DESCRIPTION
This PR adds the `github-actions` ecosystem to Dependabot, automating the maintenance of pinned SHA versions for our pipeline dependencies. 

It also carefully updates the `.jules/cicd.md` tracking file, ensuring previous notes and metrics are retained.

---
*PR created automatically by Jules for task [18279402531564519168](https://jules.google.com/task/18279402531564519168) started by @saint2706*