### PR TITLE
CI/CD: Add github-actions to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.jules/cicd.md
+++ b/.jules/cicd.md
@@ -12,3 +12,8 @@
 
 ## Further checks required
 - None
+# CI/CD Pipeline Optimizations
+
+## Date: $(date +"%Y-%m-%d")
+- Added `github-actions` package-ecosystem to `.github/dependabot.yml`.
+  - **Why:** To enable Dependabot to automatically track, update, and manage versions for pinned SHA GitHub Actions, aligning with our security best practices for CI/CD infrastructure.


### PR DESCRIPTION
# CI/CD Optimization

Added `github-actions` package-ecosystem to Dependabot to track updates for securely pinned GitHub Actions used across the workflows. All tests and lint steps have passed.

---
*PR created automatically by Jules for task [1775992032907603259](https://jules.google.com/task/1775992032907603259) started by @saint2706*