### PR TITLE
🧘 Buddha: [SEO] Removed duplicate h1 tag in MarkAttendance.tsx

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -30,3 +30,4 @@
 
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
 - [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy
+- [SEO] Removed duplicate `<h1>` in `MarkAttendance.tsx` to ensure a strict h1-h6 semantic HTML hierarchy.

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -211,7 +211,6 @@ export const MarkAttendance = () => {
 
     return (
         <main className="mark-attendance animate-fade-in">
-            <h1 className="sr-only">Mark Attendance</h1>
             <title>Mark Attendance - Smart Attendance System</title>
             <meta name="description" content="Mark your time-in or time-out using face recognition." />
             <meta name="robots" content="noindex, nofollow" />


### PR DESCRIPTION
This PR addresses a minor SEO/semantic HTML issue where `frontend/src/pages/MarkAttendance.tsx` rendered two `<h1>` tags (one `sr-only` and one visual). This violates the best practice of having exactly one `<h1>` per page. The redundant `sr-only` `<h1>` was removed.

Changes:
- Removed `<h1 className="sr-only">Mark Attendance</h1>` from `frontend/src/pages/MarkAttendance.tsx`.
- Updated `.jules/buddha-scroll.md` to document the SEO improvement.
- Full stack tests (`make test-fast`), frontend lint, and frontend build pass successfully.

---
*PR created automatically by Jules for task [1978923442736708955](https://jules.google.com/task/1978923442736708955) started by @saint2706*