### PR TITLE
📚 Docs: replace vite template with custom frontend README

### DIFF
--- a/.jules/docs-progress.md
+++ b/.jules/docs-progress.md
@@ -42,3 +42,4 @@
   - Removed trailing slash from URLs `http://127.0.0.1:8000/` and `http://localhost:5173/` in `docs/QUICKSTART.md` to resolve broken link checks.
   - Verified `make lint` and `cd frontend && pnpm run lint` pass without errors.
   - Verified `cd frontend && pnpm run build` completes successfully.
+- **2025-03-08 (Session 9)**: Audited project documentation and codebase to ensure clarity, accuracy, and completeness. Replaced `frontend/README.md` (which contained the default Vite template text and had 2 broken links flagged by `markdown-link-check`) with a properly structured Frontend README that describes our React app and links to the project docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1337,6 +1337,7 @@ This changelog was initially reconstructed from the git history on 2025-11-29, a
 - Bump urllib3 from 2.5.0 to 2.6.0 in the pip group (`6b55304`)
 
 ### Documentation (Unreleased)
+- Replaced the default Vite template `frontend/README.md` with a custom Frontend README to fix broken links and provide accurate setup instructions.
 
 - Comprehensive documentation refresh for 2026: updated React SPA frontend references, fixed broken links, updated agent instructions
 - Added missing JSDoc/TSDoc comments to exported frontend components and API functions

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,4 +35,3 @@ This directory contains the React-based frontend application for the Smart Atten
    ```
 
 For detailed usage, refer to the [User Guide](../docs/USER_GUIDE.md) and [Developer Guide](../docs/DEVELOPER_GUIDE.md).
-

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,38 @@
-# React + TypeScript + Vite
+# Frontend - Smart Attendance System
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the React-based frontend application for the Smart Attendance System.
 
-Currently, two official plugins are available:
+## Technology Stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **React 19**
+- **TypeScript**
+- **Vite**
+- **React Router v7**
+- **Tailwind CSS**
+- **TanStack React Query**
+- **Lucide Icons**
 
-## React Compiler
+## Getting Started
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+1. Install dependencies:
+   ```bash
+   pnpm install
+   ```
 
-## Expanding the ESLint configuration
+2. Start the development server:
+   ```bash
+   pnpm run dev
+   ```
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+3. Build for production:
+   ```bash
+   pnpm run build
+   ```
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+4. Run linting:
+   ```bash
+   pnpm run lint
+   ```
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+For detailed usage, refer to the [User Guide](../docs/USER_GUIDE.md) and [Developer Guide](../docs/DEVELOPER_GUIDE.md).
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```


### PR DESCRIPTION
Replaced the default Vite boilerplate `frontend/README.md` with a custom Frontend README to fix broken links and provide accurate project setup instructions. Updated documentation progress and changelog.

---
*PR created automatically by Jules for task [4700827711557046512](https://jules.google.com/task/4700827711557046512) started by @saint2706*