### PR TITLE
🎨 Picasso: [UX improvement] add loading state screen reader text

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -64,3 +64,5 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 
 - Added `aria-errormessage` attributes to the username and password input fields in `Login.tsx` to properly associate the error messages with the inputs for screen reader users, improving form accessibility and validation feedback.
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
+- Added sr-only loading text for screen readers next to Loader2 spinners in Dashboard, Login, and MarkAttendance pages.
+- Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Signing in...', 'Processing...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -94,7 +94,10 @@ export const Dashboard = () => {
                         <p className="text-muted mb-md">We couldn't retrieve the latest dashboard data.</p>
                         <button onClick={() => fetchStats()} className="btn btn-secondary" title="Retry loading statistics" disabled={isLoadingStats} aria-busy={isLoadingStats}>
                             {isLoadingStats ? (
-                                <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                                <>
+                                    <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                                    <span className="sr-only">Loading...</span>
+                                </>
                             ) : (
                                 <RefreshCw size={18} aria-hidden="true" />
                             )}

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -244,7 +244,10 @@ export const MarkAttendance = () => {
                             <p>{error}</p>
                             <button onClick={startCamera} className="btn btn-primary" title="Retry connecting to camera" disabled={isInitializing} aria-busy={isInitializing}>
                                 {isInitializing ? (
-                                    <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                                    <>
+                                        <Loader2 size={18} className="animate-spin" aria-hidden="true" />
+                                        <span className="sr-only">Loading...</span>
+                                    </>
                                 ) : (
                                     <RefreshCw size={18} aria-hidden="true" />
                                 )}


### PR DESCRIPTION
Add `sr-only` loading text to icon-only buttons using `Loader2` for better screen reader accessibility.

---
*PR created automatically by Jules for task [14545440988377844192](https://jules.google.com/task/14545440988377844192) started by @saint2706*