### PR TITLE
🔌 API: Ensure OPTIONS method returns JSON for FaceRecognitionAPI

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -390,6 +390,11 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def options(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        response = JsonResponse({})
+        response["Allow"] = "POST, OPTIONS"
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -367,6 +367,11 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def options(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+        response = JsonResponse({})
+        response["Allow"] = "POST, OPTIONS"
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 


### PR DESCRIPTION
Implemented explicit `options` method overrides in `FaceRecognitionAPI` to ensure consistent JSON content types are returned for all methods, adhering to API persona boundaries. Verified backend tests, frontend builds, and linter checks pass cleanly.

---
*PR created automatically by Jules for task [7753480547213663664](https://jules.google.com/task/7753480547213663664) started by @saint2706*