### PR TITLE
🎨 Picasso: [UX improvement] Removed redundant sr-only announcements

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -66,3 +66,4 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
 - Added sr-only loading text for screen readers next to Loader2 spinners in Dashboard, Login, and MarkAttendance pages.
 - Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Signing in...', 'Processing...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.
+- Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Retrying...', 'Try Again') since it creates a redundant announcement on screen readers. Removed redundant `<span className="sr-only">Loading...</span>` from Dashboard and MarkAttendance pages.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -96,7 +96,6 @@ export const Dashboard = () => {
                             {isLoadingStats ? (
                                 <>
                                     <Loader2 size={18} className="animate-spin" aria-hidden="true" />
-                                    <span className="sr-only">Loading...</span>
                                 </>
                             ) : (
                                 <RefreshCw size={18} aria-hidden="true" />

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -245,7 +245,6 @@ export const MarkAttendance = () => {
                                 {isInitializing ? (
                                     <>
                                         <Loader2 size={18} className="animate-spin" aria-hidden="true" />
-                                        <span className="sr-only">Loading...</span>
                                     </>
                                 ) : (
                                     <RefreshCw size={18} aria-hidden="true" />


### PR DESCRIPTION
Removes redundant screen reader only "Loading..." text from loading states in the Dashboard and Mark Attendance components where adjacent visible text describing the loading state already exists. This cleans up accessibility announcements and adheres to WCAG best practices.

---
*PR created automatically by Jules for task [2670998595237063895](https://jules.google.com/task/2670998595237063895) started by @saint2706*