### PR TITLE
🔌 API: Use JsonResponse for OPTIONS in FaceRecognitionAPI

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -390,6 +390,11 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def options(self, request, *args, **kwargs):
+        response = JsonResponse({})
+        response["Allow"] = ", ".join(self._allowed_methods()).upper()
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -367,6 +367,11 @@ class FaceRecognitionAPI(View):
 
     http_method_names = ["post", "options"]
 
+    def options(self, request, *args, **kwargs):
+        response = JsonResponse({})
+        response["Allow"] = ", ".join(self._allowed_methods()).upper()
+        return response
+
     def _authenticate_request(self, request) -> tuple[bool, Optional[str], Optional[str]]:
         """Validate session, API key, or JWT credentials for API access."""
 


### PR DESCRIPTION
- **What:** Refactored the `options` method in `FaceRecognitionAPI` (in both `recognition/views.py` and `recognition/views_legacy.py`) to return a `JsonResponse` populated with the allowed HTTP methods.
- **Why:** To prevent the default behavior of returning an empty `HttpResponse` with a `text/html` Content-Type on an API endpoint, ensuring content type consistency and adhering to API best practices. Using `_allowed_methods()` instead of directly reading `http_method_names` is also a safer practice in Django class-based views.
- **How:** Explicitly overridden the `options` method to create a `JsonResponse({})` and set the `Allow` header using `", ".join(self._allowed_methods()).upper()`.

---
*PR created automatically by Jules for task [13725179496262186208](https://jules.google.com/task/13725179496262186208) started by @saint2706*