### PR TITLE
ci: add concurrency block to frontend-ci.yml

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,6 +14,10 @@ name: Frontend CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added a concurrency block to `.github/workflows/frontend-ci.yml` grouped by workflow and ref with `cancel-in-progress: true`. This matches `ci.yml` and optimizes pipeline queue times by aborting redundant runs. Tested file correctness with `yamllint`.

---
*PR created automatically by Jules for task [16495078940892824967](https://jules.google.com/task/16495078940892824967) started by @saint2706*