### PR TITLE
🔍 Hunter: Fixed 1 error - API tests failing with 301 redirects

### DIFF
--- a/.jules/hunter-progress.md
+++ b/.jules/hunter-progress.md
@@ -42,3 +42,4 @@
 - `tests/recognition/test_performance.py`: Ran black to fix line length issues.
 - `tests/recognition/test_face_recognition_api.py`: Removed invalid `F401` from the `noqa` comment for `from recognition import views_legacy`.
 - `tests/recognition/test_api_views.py.orig`: Removed the `.orig` backup file.
+- `tests/recognition/test_api_attendance_n_plus_one.py`, `tests/recognition/test_api_security_sentinel.py`, `tests/recognition/test_api_views.py`: Fixed failing tests returning 301 redirects by decorating with `@override_settings(SECURE_SSL_REDIRECT=False)`.

--- a/tests/recognition/test_api_attendance_n_plus_one.py
+++ b/tests/recognition/test_api_attendance_n_plus_one.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
 from django.db import connection
+from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
@@ -11,6 +12,7 @@ from users.models import Direction, RecognitionAttempt
 
 
 @pytest.mark.django_db
+@override_settings(SECURE_SSL_REDIRECT=False)
 def test_attendance_api_query_count():
     User = get_user_model()
     admin = User.objects.create(

--- a/tests/recognition/test_api_security_sentinel.py
+++ b/tests/recognition/test_api_security_sentinel.py
@@ -12,6 +12,7 @@ from users.models import RecognitionAttempt
 
 @pytest.mark.django_db
 @override_settings(
+    SECURE_SSL_REDIRECT=False,
     RECOGNITION_API_KEYS=("secure-key-1",),
     RECOGNITION_DISTANCE_THRESHOLD=0.5,
     DEEPFACE_OPTIMIZATIONS={
@@ -52,7 +53,7 @@ def test_long_username_truncation(client, monkeypatch):
 
 
 @pytest.mark.django_db
-@override_settings(RECOGNITION_API_KEYS=("secure-key-1", "secure-key-2"))
+@override_settings(SECURE_SSL_REDIRECT=False, RECOGNITION_API_KEYS=("secure-key-1", "secure-key-2"))
 def test_api_key_authentication_works(client, monkeypatch):
     cache.clear()
 

--- a/tests/recognition/test_api_views.py
+++ b/tests/recognition/test_api_views.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.contrib.auth import get_user_model
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -38,6 +39,7 @@ def normal_user():
 
 @pytest.mark.django_db
 class TestUserViewSet:
+    @override_settings(SECURE_SSL_REDIRECT=False)
     def test_list_users_staff(self, api_client, admin_user, normal_user):
         api_client.force_authenticate(user=admin_user)
         url = reverse("user-list")
@@ -46,6 +48,7 @@ class TestUserViewSet:
         # Staff should see all users
         assert len(response.data["results"]) == 2
 
+    @override_settings(SECURE_SSL_REDIRECT=False)
     def test_list_users_non_staff(self, api_client, normal_user, admin_user):
         api_client.force_authenticate(user=normal_user)
         url = reverse("user-list")
@@ -55,6 +58,7 @@ class TestUserViewSet:
         assert len(response.data["results"]) == 1
         assert response.data["results"][0]["username"] == "normal"
 
+    @override_settings(SECURE_SSL_REDIRECT=False)
     def test_me_endpoint(self, api_client, normal_user):
         api_client.force_authenticate(user=normal_user)
         url = reverse("user-me")


### PR DESCRIPTION
Fixed failing API tests that were returning 301 redirects due to secure defaults forcing SSL redirects. Added `@override_settings(SECURE_SSL_REDIRECT=False)` to the affected tests. Build now passes ✅.

---
*PR created automatically by Jules for task [10862016905197625729](https://jules.google.com/task/10862016905197625729) started by @saint2706*