### PR TITLE
🎨 Picasso: [UX improvement] removed redundant ARIA labels and screen reader text

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -66,3 +66,5 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
 - Added sr-only loading text for screen readers next to Loader2 spinners in Dashboard, Login, and MarkAttendance pages.
 - Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Signing in...', 'Processing...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.
+- Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Retrying...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.
+- Removed redundant aria-label from links that already contain visible text that matches their purpose (e.g. "Setup Wizard" in Dashboard.tsx).

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -78,7 +78,7 @@ export const Dashboard = () => {
                     <p className="text-muted">{getGreeting()}, {user?.username}!</p>
                 </div>
                 <div className="header-actions">
-                    <Link to="/setup-wizard" className="btn btn-primary" title="Start the Setup Wizard" aria-label="Start Setup Wizard">
+                    <Link to="/setup-wizard" className="btn btn-primary" title="Start the Setup Wizard">
                         Setup Wizard
                     </Link>
                 </div>
@@ -96,7 +96,6 @@ export const Dashboard = () => {
                             {isLoadingStats ? (
                                 <>
                                     <Loader2 size={18} className="animate-spin" aria-hidden="true" />
-                                    <span className="sr-only">Loading...</span>
                                 </>
                             ) : (
                                 <RefreshCw size={18} aria-hidden="true" />

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -245,7 +245,6 @@ export const MarkAttendance = () => {
                                 {isInitializing ? (
                                     <>
                                         <Loader2 size={18} className="animate-spin" aria-hidden="true" />
-                                        <span className="sr-only">Loading...</span>
                                     </>
                                 ) : (
                                     <RefreshCw size={18} aria-hidden="true" />


### PR DESCRIPTION
Removed redundant screen reader texts and `aria-label`s to improve accessibility compliance and prevent redundant screen reader announcements across Dashboard and Mark Attendance components.

---
*PR created automatically by Jules for task [17392085444495587282](https://jules.google.com/task/17392085444495587282) started by @saint2706*