### PR TITLE
⚡ Bolt: Consolidate animate-spin CSS

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,7 @@
 - Found multiple `.aggregate()` queries being executed consecutively against the same queryset in `recognition/scheduled_tasks.py` (`scheduled_liveness_evaluation`).
 - **Optimization:** Refactored these sequential database queries into a single `.aggregate()` call using `Count("id")`, `Count("id", filter=Q(...))`, and `Avg("liveness_confidence", filter=Q(...))` to minimize database roundtrips.
 - **Result:** Decreased query count from 2 to 1 on the scheduled liveness evaluation Celery task.
+## Optimization: CSS build failure due to duplicate @keyframes
+- **Problem**: The frontend build failed with `Unexpected "}" [css-syntax-error]` due to a duplicate `@keyframes spin` definition that was partially removed but left a syntax error in `frontend/src/pages/Login.css`, and a duplicate definition in `frontend/src/index.css`.
+- **Optimization**: Consolidated the `@keyframes spin` definition and the `.animate-spin` class into `frontend/src/index.css` (which is globally available) and removed the redundant definitions from `frontend/src/pages/Login.css`.
+- **Result**: Resolved the CSS syntax error, allowing the `pnpm build` process to complete successfully, and reduced duplicate CSS code.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -518,3 +518,15 @@ kbd.kbd-lg {
   min-width: 1.75em;
 }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border-width: 0; }
+@keyframes spin {
+  from {
+      transform: rotate(0deg);
+  }
+  to {
+      transform: rotate(360deg);
+  }
+}
+
+.animate-spin {
+  animation: spin 1s linear infinite;
+}

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -111,17 +111,3 @@
     padding-top: var(--spacing-lg);
     border-top: 1px solid var(--color-border);
 }
-
-@keyframes spin {
-    from {
-        transform: rotate(0deg);
-    }
-
-    to {
-        transform: rotate(360deg);
-    }
-}
-
-.animate-spin {
-    animation: spin 1s linear infinite;
-}


### PR DESCRIPTION
- Consolidated the `@keyframes spin` definition and the `.animate-spin` class into `frontend/src/index.css`.
- Removed duplicate definitions from `frontend/src/pages/Login.css` to fix a `pnpm build` syntax error.
- Reduced duplicate CSS code and documented the improvement.

---
*PR created automatically by Jules for task [1352663287172946470](https://jules.google.com/task/1352663287172946470) started by @saint2706*