### PR TITLE
ci: optimize workflows with concurrency cancel-in-progress

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,10 @@ permissions:
   contents: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,6 +14,10 @@ name: Frontend CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -36,6 +36,10 @@ name: Lighthouse CI
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.jules/ci-cd-progress.md
+++ b/.jules/ci-cd-progress.md
@@ -1,0 +1,14 @@
+# CI/CD Pipeline Optimizations
+
+## Concurrency and Resource Optimization
+- **Added `concurrency` blocks to multiple GitHub Actions workflows:**
+  - `codeql.yml`
+  - `frontend-ci.yml`
+  - `lighthouse.yml`
+- **Configuration Details:**
+  - `group: ${{ github.workflow }}-${{ github.ref }}`: Groups runs by workflow name and branch reference.
+  - `cancel-in-progress: true`: Automatically cancels any currently running jobs for the same branch when a new commit is pushed.
+- **Impact:**
+  - Saves significant runner minutes and queue time by preventing redundant pipeline executions.
+  - Speeds up the feedback loop for developers by ensuring only the latest commit is validated.
+  - Avoids race conditions on shared deploy/test environments.


### PR DESCRIPTION
Added `concurrency` blocks to `codeql.yml`, `frontend-ci.yml`, and `lighthouse.yml` to automatically cancel redundant, in-progress CI runs when new commits are pushed to the same branch. This saves GitHub Actions runner minutes and improves developer feedback loops.

---
*PR created automatically by Jules for task [7006995088672452727](https://jules.google.com/task/7006995088672452727) started by @saint2706*