### PR TITLE
🧘 Buddha: [SEO] Fixed MarkAttendance semantic hierarchy

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -31,3 +31,4 @@
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
 - [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy
 - [SEO] Removed duplicate `<h1>` in `MarkAttendance.tsx` to ensure a strict h1-h6 semantic HTML hierarchy.
+- [SEO] Added sr-only h1 tag to MarkAttendance.tsx for semantic hierarchy.

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -229,7 +229,8 @@ export const MarkAttendance = () => {
             <div className="attendance-container">
                 <header className="attendance-header">
                     <Clock width={32} height={32} className="header-icon" aria-hidden="true" />
-                    <h1>Mark Time-{direction === 'in' ? 'In' : 'Out'}</h1>
+                    <h1 className="sr-only">Mark Attendance</h1>
+                    <h2>Mark Time-{direction === 'in' ? 'In' : 'Out'}</h2>
                     <p className="text-muted">
                         Position your face in the camera and click capture
                     </p>


### PR DESCRIPTION
Implemented semantic HTML hierarchy improvements for the `MarkAttendance` page.

- Added an `<h1 className="sr-only">Mark Attendance</h1>` tag.
- Changed the existing `<h1>Mark Time...</h1>` to an `<h2>` tag to maintain the one-h1-per-page rule for SEO and accessibility.

---
*PR created automatically by Jules for task [11284801344514580668](https://jules.google.com/task/11284801344514580668) started by @saint2706*