### PR TITLE
🎨 Picasso: [accessibility] Improve ARIA labels and redundant sr-only text

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -66,3 +66,4 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
 - Added sr-only loading text for screen readers next to Loader2 spinners in Dashboard, Login, and MarkAttendance pages.
 - Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Signing in...', 'Processing...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.
+- Improved ARIA labels and removed redundant sr-only text

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -84,7 +84,7 @@ export const Navbar = () => {
                     <button
                         onClick={toggleTheme}
                         className="btn btn-icon theme-toggle"
-                            aria-label="Toggle theme"
+                            aria-label={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                             aria-pressed={resolvedTheme === 'dark'}
                             title={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                     >
@@ -94,7 +94,7 @@ export const Navbar = () => {
                     <button
                         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                         className="btn btn-icon mobile-menu-toggle"
-                            aria-label="Toggle mobile menu"
+                            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
                             title={mobileMenuOpen ? "Close menu" : "Open menu"}
                             aria-expanded={mobileMenuOpen}
                             aria-controls="mobile-menu"

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -94,10 +94,7 @@ export const Dashboard = () => {
                         <p className="text-muted mb-md">We couldn't retrieve the latest dashboard data.</p>
                         <button onClick={() => fetchStats()} className="btn btn-secondary" title="Retry loading statistics" disabled={isLoadingStats} aria-busy={isLoadingStats}>
                             {isLoadingStats ? (
-                                <>
-                                    <Loader2 size={18} className="animate-spin" aria-hidden="true" />
-                                    <span className="sr-only">Loading...</span>
-                                </>
+                                <Loader2 size={18} className="animate-spin" aria-hidden="true" />
                             ) : (
                                 <RefreshCw size={18} aria-hidden="true" />
                             )}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -128,7 +128,7 @@ export const Login = () => {
                                 type="button"
                                 className="password-toggle"
                                 onClick={() => setShowPassword(!showPassword)}
-                                aria-label="Toggle password visibility"
+                                aria-label={showPassword ? 'Hide password' : 'Show password'}
                                 aria-pressed={showPassword}
                                 title={showPassword ? 'Hide password' : 'Show password'}
                                 disabled={isLoading}


### PR DESCRIPTION
This PR adds UX and accessibility polish per the Picasso persona guidelines.

Changes:
* **Navbar.tsx:** The theme toggle and mobile menu buttons now use dynamic `aria-label` properties reflecting the current application state, improving screen reader context.
* **Login.tsx:** The password visibility toggle button now uses a dynamic `aria-label` ("Show password" / "Hide password").
* **Dashboard.tsx:** Removed a redundant `<span className="sr-only">Loading...</span>` since the adjacent visible text correctly announces the loading state, reducing noise for screen reader users.

Tested using standard build and lint commands. Added a log of learnings and changes to `.jules/picasso.md`.

---
*PR created automatically by Jules for task [14734675917485673618](https://jules.google.com/task/14734675917485673618) started by @saint2706*