### PR TITLE
☸️ Kubernetes: Pin Postgres and Redis container images with SHA256 digests

### DIFF
--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:16.2-alpine
+          image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.2.13-alpine
+          image: redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis


### PR DESCRIPTION
Added SHA256 digests to Postgres and Redis container images for security hardening. Evaluated existing deployments and confirmed requests, limits, probes, and ConfigMaps were properly configured. Validated YAML configurations using `yamllint` and `kubeconform`. Tests and validation passed cleanly.

---
*PR created automatically by Jules for task [11237538826662869695](https://jules.google.com/task/11237538826662869695) started by @saint2706*