### PR TITLE
🧘 Buddha: [GEO] Improve aria-labels for screen reader accessibility

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -31,3 +31,4 @@
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
 - [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy
 - [SEO] Removed duplicate `<h1>` in `MarkAttendance.tsx` to ensure a strict h1-h6 semantic HTML hierarchy.
+- [GEO] Updated static aria-label values to dynamic state-reflective labels in Login.tsx and Navbar.tsx to improve screen reader accessibility.

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -84,7 +84,7 @@ export const Navbar = () => {
                     <button
                         onClick={toggleTheme}
                         className="btn btn-icon theme-toggle"
-                            aria-label="Toggle theme"
+                            aria-label={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                             aria-pressed={resolvedTheme === 'dark'}
                             title={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                     >

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -128,7 +128,7 @@ export const Login = () => {
                                 type="button"
                                 className="password-toggle"
                                 onClick={() => setShowPassword(!showPassword)}
-                                aria-label="Toggle password visibility"
+                                aria-label={showPassword ? 'Hide password' : 'Show password'}
                                 aria-pressed={showPassword}
                                 title={showPassword ? 'Hide password' : 'Show password'}
                                 disabled={isLoading}


### PR DESCRIPTION
This PR implements accessibility and GEO enhancements by updating static `aria-label`s on icon-only toggle buttons to use dynamic, state-reflective labels. Specifically, the password visibility toggle in `Login.tsx` and the theme toggle in `Navbar.tsx` now accurately announce their corresponding active states to screen readers, improving overall semantic clarity and resolving a noted anti-pattern. Progress has been logged to the `.jules/buddha-scroll.md` file.

---
*PR created automatically by Jules for task [7342787338092261666](https://jules.google.com/task/7342787338092261666) started by @saint2706*