### PR TITLE
Optimize CI/CD pipelines: pin Postgres and add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     needs: [lint]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -194,7 +194,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -272,7 +272,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/close-all-prs.yml
+++ b/.github/workflows/close-all-prs.yml
@@ -1,3 +1,4 @@
+---
 name: Close All Pull Requests
 
 "on":
@@ -6,6 +7,10 @@ name: Close All Pull Requests
 permissions:
   contents: read
   pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   close-prs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,10 @@ permissions:
   actions: read
   contents: read
   security-events: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   analyze:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -12,6 +12,10 @@ name: "Copilot Setup Steps"
   pull_request:
     paths:
       - .github/workflows/copilot-setup-steps.yml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be
@@ -27,7 +31,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,6 +6,10 @@ name: Dependency Review
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   dependency-review:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -13,6 +13,10 @@ name: Frontend CI
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   frontend-lint:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -35,6 +35,10 @@ name: Lighthouse CI
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   lighthouse:
@@ -43,7 +47,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,10 @@ name: pre-commit
 
 permissions:
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   pre-commit:


### PR DESCRIPTION
This pull request implements several pipeline optimizations to improve CI/CD speed, reliability, and security:

1. **Dependency Pinning:** Pinned the `postgres:16.2-alpine` Docker image in `ci.yml` and `lighthouse.yml` to a specific SHA256 digest (`sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27`) to guarantee reproducible deployments and avoid unexpected upstream changes.
2. **Fail-Fast (Concurrency):** Added `concurrency` blocks with `cancel-in-progress: true` to multiple workflow files (`close-all-prs.yml`, `codeql.yml`, `copilot-setup-steps.yml`, `dependency-review.yml`, `frontend-ci.yml`, `lighthouse.yml`, `pre-commit.yml`). This ensures that redundant, pending, or in-progress jobs are automatically aborted when new commits are pushed, saving significant execution resources and queue times.

All modified workflows have been validated for YAML syntax, and the test suite has passed.

---
*PR created automatically by Jules for task [4847888744169798432](https://jules.google.com/task/4847888744169798432) started by @saint2706*