### PR TITLE
🎨 Picasso: [accessibility] Use dynamic ARIA labels for stateful buttons

### DIFF
--- a/.jules/picasso.md
+++ b/.jules/picasso.md
@@ -66,3 +66,6 @@ Replaced large `size` prop with explicit `width` and `height` props on `lucide-r
 - Added `.sr-only` visually hidden text alongside the loading skeletons in `Dashboard.tsx` to explicitly announce "Loading total employees...", "Loading present today...", and "Loading system status..." to screen readers while data is being fetched.
 - Added sr-only loading text for screen readers next to Loader2 spinners in Dashboard, Login, and MarkAttendance pages.
 - Reverted the sr-only addition next to the Loader2 spinner where visible text already existed (e.g. 'Signing in...', 'Processing...') since it creates a redundant announcement on screen readers. Only kept it in icon-only buttons.
+
+## Accessibility improvements
+- Updated stateful icon buttons in Login and Navbar components to use dynamic `aria-label` properties reflecting their current state (e.g., 'Show password'/'Hide password', 'Switch to light mode'/'Switch to dark mode').

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -84,7 +84,7 @@ export const Navbar = () => {
                     <button
                         onClick={toggleTheme}
                         className="btn btn-icon theme-toggle"
-                            aria-label="Toggle theme"
+                            aria-label={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                             aria-pressed={resolvedTheme === 'dark'}
                             title={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                     >
@@ -94,7 +94,7 @@ export const Navbar = () => {
                     <button
                         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                         className="btn btn-icon mobile-menu-toggle"
-                            aria-label="Toggle mobile menu"
+                            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
                             title={mobileMenuOpen ? "Close menu" : "Open menu"}
                             aria-expanded={mobileMenuOpen}
                             aria-controls="mobile-menu"

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -128,7 +128,7 @@ export const Login = () => {
                                 type="button"
                                 className="password-toggle"
                                 onClick={() => setShowPassword(!showPassword)}
-                                aria-label="Toggle password visibility"
+                                aria-label={showPassword ? 'Hide password' : 'Show password'}
                                 aria-pressed={showPassword}
                                 title={showPassword ? 'Hide password' : 'Show password'}
                                 disabled={isLoading}


### PR DESCRIPTION
Updated stateful icon buttons in `Login.tsx` and `Navbar.tsx` components to use dynamic `aria-label` properties reflecting their current state (e.g., 'Show password'/'Hide password', 'Switch to light mode'/'Switch to dark mode'). Recorded the change in `.jules/picasso.md`.

---
*PR created automatically by Jules for task [14463407754443005330](https://jules.google.com/task/14463407754443005330) started by @saint2706*