### PR TITLE
☸️ Kubernetes: Pin database container images to SHA256 digests

### DIFF
--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:16.2-alpine
+          image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.2.13-alpine
+          image: redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis


### PR DESCRIPTION
This PR optimizes the Kubernetes StatefulSet configurations by explicitly pinning the `postgres` and `redis` container images to their respective SHA256 digests. 

This change enhances cluster security and deployment stability by preventing unexpected regressions from upstream tag mutations (e.g., mutable "alpine" tags) and aligns with Kubernetes security and compliance standards.

Changes made:
- Updated `k8s/base/postgres-statefulset.yaml` to use `postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27`
- Updated `k8s/base/redis-statefulset.yaml` to use `redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38`

These changes were validated locally using `yaml-lint` and `kubeconform`.

---
*PR created automatically by Jules for task [3233944352405528503](https://jules.google.com/task/3233944352405528503) started by @saint2706*