### PR TITLE
🧘 Buddha: [SEO] Fix semantic heading hierarchy in MarkAttendance

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -31,3 +31,4 @@
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
 - [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy
 - [SEO] Removed duplicate `<h1>` in `MarkAttendance.tsx` to ensure a strict h1-h6 semantic HTML hierarchy.
+- [SEO] Updated `<h2>` to `<h3>` in `MarkAttendance.tsx` status alerts to strictly adhere to the h1-h6 semantic HTML hierarchy.

--- a/frontend/src/pages/MarkAttendance.tsx
+++ b/frontend/src/pages/MarkAttendance.tsx
@@ -310,7 +310,7 @@ export const MarkAttendance = () => {
                                 <>
                                     <CheckCircle width={32} height={32} aria-hidden="true" />
                                     <div>
-                                        <h2>Attendance Marked!</h2>
+                                        <h3>Attendance Marked!</h3>
                                         <p>Welcome, {result.username}</p>
                                         {result.confidence && (
                                             <span className="badge badge-success">
@@ -323,7 +323,7 @@ export const MarkAttendance = () => {
                                 <>
                                     <AlertTriangle width={32} height={32} aria-hidden="true" />
                                     <div>
-                                        <h2>Liveness Check Failed</h2>
+                                        <h3>Liveness Check Failed</h3>
                                         <p>Please try again with your actual face</p>
                                     </div>
                                 </>
@@ -331,7 +331,7 @@ export const MarkAttendance = () => {
                                 <>
                                     <XCircle width={32} height={32} aria-hidden="true" />
                                     <div>
-                                        <h2>Not Recognized</h2>
+                                        <h3>Not Recognized</h3>
                                         <p>{result.message}</p>
                                     </div>
                                 </>


### PR DESCRIPTION
This PR fixes a minor SEO issue in `MarkAttendance.tsx` where an `<h2>` was being used inside status alerts without preceding the correct hierarchy structure. By changing these tags to `<h3>`, we ensure strict semantic HTML adherence which is beneficial for both accessibility and Generative Engine Optimization (GEO).

---
*PR created automatically by Jules for task [4919489961678165783](https://jules.google.com/task/4919489961678165783) started by @saint2706*