### PR TITLE
⚡ Bolt: [Optimization] Prevent redundant queries in attendance views

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -72,3 +72,8 @@
 - Found multiple `.aggregate()` queries being executed consecutively against the same queryset in `recognition/scheduled_tasks.py` (`scheduled_liveness_evaluation`).
 - **Optimization:** Refactored these sequential database queries into a single `.aggregate()` call using `Count("id")`, `Count("id", filter=Q(...))`, and `Avg("liveness_confidence", filter=Q(...))` to minimize database roundtrips.
 - **Result:** Decreased query count from 2 to 1 on the scheduled liveness evaluation Celery task.
+
+## Optimization: Prevent redundant queries in attendance views
+- **Problem**: In `recognition/views.py` and `recognition/views_legacy.py`, `present_qs.exists()` was used before passing the queryset to `hours_vs_employee_given_date` and `hours_vs_date_given_employee`. This caused a redundant database query because the queryset was immediately iterated over within those functions.
+- **Optimization**: Replaced `present_qs.exists()` with `if present_qs:` to utilize implicit boolean evaluation. This fetches and caches the queryset in a single query, preventing the N+1-like redundant database hit.
+- **Result**: Reduced the number of database queries by 1 for the admin attendance views (e.g. `view_attendance_date`).

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -3371,7 +3371,7 @@ def view_attendance_date(request):
             time_qs = Time.objects.filter(date=date).select_related("user")
             present_qs = Present.objects.filter(date=date).select_related("user")
 
-            if present_qs.exists():
+            if present_qs:
                 qs, chart_url = hours_vs_employee_given_date(present_qs, time_qs)
             else:
                 messages.warning(request, "No records for the selected date.")
@@ -3421,7 +3421,7 @@ def view_attendance_employee(request):
                     .order_by("-date")
                 )
 
-                if present_qs.exists():
+                if present_qs:
                     qs, chart_url = hours_vs_date_given_employee(present_qs, time_qs, admin=True)
                 else:
                     messages.warning(request, "No records for the selected duration.")
@@ -3468,7 +3468,7 @@ def view_my_attendance_employee_login(request):
                 .order_by("-date")
             )
 
-            if present_qs.exists():
+            if present_qs:
                 qs, chart_url = hours_vs_date_given_employee(present_qs, time_qs, admin=False)
             else:
                 messages.warning(request, "No records for the selected duration.")

--- a/recognition/views_legacy.py
+++ b/recognition/views_legacy.py
@@ -3575,7 +3575,7 @@ def view_attendance_date(request):
             time_qs = Time.objects.filter(date=date).select_related("user")
             present_qs = Present.objects.filter(date=date).select_related("user")
 
-            if present_qs.exists():
+            if present_qs:
                 qs, chart_url = hours_vs_employee_given_date(present_qs, time_qs)
             else:
                 messages.warning(request, "No records for the selected date.")
@@ -3625,7 +3625,7 @@ def view_attendance_employee(request):
                     .order_by("-date")
                 )
 
-                if present_qs.exists():
+                if present_qs:
                     qs, chart_url = hours_vs_date_given_employee(present_qs, time_qs)
                 else:
                     messages.warning(request, "No records for the selected duration.")
@@ -3672,7 +3672,7 @@ def view_my_attendance_employee_login(request):
                 .order_by("-date")
             )
 
-            if present_qs.exists():
+            if present_qs:
                 qs, chart_url = hours_vs_date_given_employee(present_qs, time_qs)
             else:
                 messages.warning(request, "No records for the selected duration.")


### PR DESCRIPTION
In `recognition/views.py` and `recognition/views_legacy.py`, `present_qs.exists()` was being used right before passing the `present_qs` queryset to `hours_vs_employee_given_date` and `hours_vs_date_given_employee`. Because those functions immediately iterate over the queryset, using `.exists()` resulted in an unnecessary `SELECT EXISTS` query followed immediately by a full `SELECT` query.

This change replaces `if present_qs.exists():` with `if present_qs:` taking advantage of Django's implicit boolean evaluation. This fetches the queryset and populates its internal cache in a single query, eliminating the N+1-like redundant database hit in the `view_attendance_date`, `view_attendance_employee`, and `view_my_attendance_employee_login` views.

Backend tests have been verified to pass successfully. The optimization and outcome have been documented in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [17671222711349635811](https://jules.google.com/task/17671222711349635811) started by @saint2706*