### PR TITLE
ci: pin postgres Docker image digest in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     needs: [lint]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -194,7 +194,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -272,7 +272,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams


### PR DESCRIPTION
Pinned the `postgres:16.2-alpine` Docker image across GitHub workflows to use its SHA256 digest (`postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27`). This mitigates risks associated with mutable tags and aligns with infrastructure-as-code and CI/CD security guidelines. Verified via testing that this does not negatively impact existing jobs.

---
*PR created automatically by Jules for task [3768370666871205603](https://jules.google.com/task/3768370666871205603) started by @saint2706*