### PR TITLE
🐳 Docker: [Security] Uninstall packaging tools from production virtual environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.product
     RECOGNITION_JWT_SECRET=dummy-jwt-secret-for-build \
     python manage.py collectstatic --noinput \
     && rm -rf /app/frontend \
+    && /venv/bin/pip uninstall -y setuptools wheel pip \
     && find /venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true \
     && find /venv -type f -name "*.pyc" -delete \
     && find /venv -type f -name "*.pyo" -delete

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -113,6 +113,7 @@ RUN DJANGO_SETTINGS_MODULE=attendance_system_facial_recognition.settings.product
     RECOGNITION_JWT_SECRET=dummy-jwt-secret-for-build \
     python manage.py collectstatic --noinput \
     && rm -rf /app/frontend \
+    && /venv/bin/pip uninstall -y setuptools wheel pip \
     && find /venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true \
     && find /venv -type f -name "*.pyc" -delete \
     && find /venv -type f -name "*.pyo" -delete


### PR DESCRIPTION
Removed vulnerable python packaging tools (`pip`, `setuptools`, `wheel`) from the virtual environments inside the Dockerfiles to improve security and container size.

---
*PR created automatically by Jules for task [848450249621213864](https://jules.google.com/task/848450249621213864) started by @saint2706*