### PR TITLE
🔌 API: Fix Path Disclosure in FaceRecognitionAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog was initially reconstructed from the git history on 2025-11-29, a
 
 - docs: Documented `/admin/health/` endpoint in `docs/API_REFERENCE.md` as per good first issue.
 - docs: Improved troubleshooting guide in `docs/troubleshooting.md` with common issues and solutions.
+- API: Modified FaceRecognitionAPI to only return the filename instead of the full path in the identity field to fix a path disclosure vulnerability.
 
 ### Fixed
 

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -1022,7 +1022,7 @@ class FaceRecognitionAPI(View):
         response_payload.update(
             {
                 "distance": float(distance_value),
-                "identity": identity_path,
+                "identity": Path(identity_path).name if identity_path else None,
             }
         )
         if username:


### PR DESCRIPTION
Fixed a path disclosure vulnerability in the `FaceRecognitionAPI` by extracting and returning only the filename of the matched identity rather than the full absolute server path. This prevents leakage of internal directory structure. This breaking API change has also been documented in the `CHANGELOG.md`.

---
*PR created automatically by Jules for task [15543605784986632001](https://jules.google.com/task/15543605784986632001) started by @saint2706*