### PR TITLE
🔒 Kubernetes: Pin container images to SHA256 digests

### DIFF
--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:16.2-alpine
+          image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.2.13-alpine
+          image: redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis


### PR DESCRIPTION
As the 'Kubernetes' persona, I've implemented a critical security improvement to the Kubernetes manifests.

### What Changed?
1. **Pinned PostgreSQL Image**: Updated the `postgres` StatefulSet to use the exact SHA256 digest for `postgres:16.2-alpine`.
2. **Pinned Redis Image**: Updated the `redis` StatefulSet to use the exact SHA256 digest for `redis:7.2.13-alpine`.

### Why?
By pinning container image versions using their SHA256 digests rather than relying solely on tags (like `16.2-alpine`), we guarantee that the cluster will always deploy the exact same immutable image artifact. This protects against scenarios where an upstream repository might silently update a tag (either intentionally or via compromise), which can introduce regressions or vulnerabilities.

*Note: During the discovery phase, I verified that resource requests/limits, liveness/readiness probes, and security contexts were already correctly implemented across all Deployments and StatefulSets according to the defined persona boundaries.*

---
*PR created automatically by Jules for task [9516712628300691491](https://jules.google.com/task/9516712628300691491) started by @saint2706*