### PR TITLE
🧘 Buddha: [SEO] Improve accessibility with dynamic aria-labels

### DIFF
--- a/.jules/buddha-scroll.md
+++ b/.jules/buddha-scroll.md
@@ -31,3 +31,4 @@
 - [GEO/SEO] Synchronized and updated llms.txt and robots.txt to properly account for missing protected routes, task endpoints, and API boundaries.
 - [SEO] Added missing <h1> tag to MarkAttendance.tsx for semantic HTML hierarchy
 - [SEO] Removed duplicate `<h1>` in `MarkAttendance.tsx` to ensure a strict h1-h6 semantic HTML hierarchy.
+- [SEO] Replaced static aria-labels with dynamic ones in Navbar and Login to properly announce state changes to screen readers.

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -84,7 +84,7 @@ export const Navbar = () => {
                     <button
                         onClick={toggleTheme}
                         className="btn btn-icon theme-toggle"
-                            aria-label="Toggle theme"
+                            aria-label={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                             aria-pressed={resolvedTheme === 'dark'}
                             title={resolvedTheme === 'dark' ? "Switch to light mode" : "Switch to dark mode"}
                     >
@@ -94,7 +94,7 @@ export const Navbar = () => {
                     <button
                         onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
                         className="btn btn-icon mobile-menu-toggle"
-                            aria-label="Toggle mobile menu"
+                            aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
                             title={mobileMenuOpen ? "Close menu" : "Open menu"}
                             aria-expanded={mobileMenuOpen}
                             aria-controls="mobile-menu"

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -128,7 +128,7 @@ export const Login = () => {
                                 type="button"
                                 className="password-toggle"
                                 onClick={() => setShowPassword(!showPassword)}
-                                aria-label="Toggle password visibility"
+                                aria-label={showPassword ? 'Hide password' : 'Show password'}
                                 aria-pressed={showPassword}
                                 title={showPassword ? 'Hide password' : 'Show password'}
                                 disabled={isLoading}


### PR DESCRIPTION
Replaced static aria-labels with dynamic ones in `Navbar.tsx` and `Login.tsx` to properly announce state changes (e.g., "Switch to dark mode", "Hide password") to screen readers. Updated `.jules/buddha-scroll.md` to document the changes.

---
*PR created automatically by Jules for task [12237866602268654674](https://jules.google.com/task/12237866602268654674) started by @saint2706*