### PR TITLE
chore: pin docker image digests in kubernetes manifests

### DIFF
--- a/k8s/base/postgres-statefulset.yaml
+++ b/k8s/base/postgres-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: postgres
-          image: postgres:16.2-alpine
+          image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
           imagePullPolicy: IfNotPresent
           ports:
             - name: postgres

--- a/k8s/base/redis-statefulset.yaml
+++ b/k8s/base/redis-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: redis
-          image: redis:7.2.13-alpine
+          image: redis:7.2.13-alpine@sha256:9907ac0c435717b4d95697cb4d0ce77d100b1d21269a01a0ce66f27335184c38
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis


### PR DESCRIPTION
Pinned exact SHA256 digests for PostgreSQL and Redis images in their respective Kubernetes StatefulSet manifests. This adheres to Kubernetes deployment best practices for immutable deployments, preventing supply-chain vulnerabilities and tag mutability issues. Cleaned up downloaded kubeconform binary and ensured all backend and frontend validation passes.

---
*PR created automatically by Jules for task [15483798444260335014](https://jules.google.com/task/15483798444260335014) started by @saint2706*