### PR TITLE
build(ci): pin postgres image with sha256 digest in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     needs: [lint]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -194,7 +194,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams
@@ -272,7 +272,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16.2-alpine
+        image: postgres:16.2-alpine@sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27
         env:
           POSTGRES_USER: ams
           POSTGRES_PASSWORD: ams


### PR DESCRIPTION
This PR pins the `postgres:16.2-alpine` docker image to its exact sha256 digest (`sha256:951bfda460300925caa3949eaa092ba022e9aec191bbea9056a39e2382260b27`) in the GitHub Action workflows (`ci.yml`, `copilot-setup-steps.yml`, and `lighthouse.yml`), fulfilling the CI/CD pipeline requirements.

---
*PR created automatically by Jules for task [13646974134345224740](https://jules.google.com/task/13646974134345224740) started by @saint2706*